### PR TITLE
Added possibility to create a DgraphClient with a specified request deadline

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -35,7 +35,7 @@ function start {
 
 function startZero {
 	echo -e "Starting dgraph zero.\n"
-  dgraph zero -w build/wz > build/zero.log --port_offset -2000 2>&1 &
+  dgraph zero -w build/wz > build/zero.log 2>&1 &
   # To ensure dgraph doesn't start before dgraphzero.
 	# It takes time for zero to start on travis(mac).
 	sleep $sleepTime

--- a/scripts/install_dgraph.sh
+++ b/scripts/install_dgraph.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ -z "$TRAVIS_TAG" ]; then
-  curl https://nightly.dgraph.io -sSf | bash
+  curl https://get.dgraph.io -sSf | bash -s nightly
 else
   curl https://get.dgraph.io -sSf | bash
 fi

--- a/src/test/java/io/dgraph/DgraphClientTest.java
+++ b/src/test/java/io/dgraph/DgraphClientTest.java
@@ -16,6 +16,8 @@
 
 package io.dgraph;
 
+import static org.junit.Assert.*;
+
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.protobuf.ByteString;
@@ -24,15 +26,12 @@ import io.dgraph.DgraphProto.*;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * @author Edgar Rodriguez-Diaz
@@ -184,7 +183,7 @@ public class DgraphClientTest extends DgraphIntegrationTest {
     method.setAccessible(true);
 
     DgraphGrpc.DgraphBlockingStub client =
-        (DgraphGrpc.DgraphBlockingStub) method.invoke(dgraphClient, null);
+        (DgraphGrpc.DgraphBlockingStub) method.invoke(dgraphClient);
 
     Thread.sleep(1001);
 

--- a/src/test/java/io/dgraph/DgraphClientTest.java
+++ b/src/test/java/io/dgraph/DgraphClientTest.java
@@ -16,19 +16,23 @@
 
 package io.dgraph;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.protobuf.ByteString;
 import io.dgraph.DgraphClient.Transaction;
 import io.dgraph.DgraphProto.*;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.StatusRuntimeException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 /**
  * @author Edgar Rodriguez-Diaz
@@ -160,6 +164,35 @@ public class DgraphClientTest extends DgraphIntegrationTest {
               .setCommitNow(true)
               .build();
       txn.mutate(mu);
+    }
+  }
+
+  @Test
+  public void testClientWithDeadline() throws Exception {
+    ManagedChannel channel =
+        ManagedChannelBuilder.forAddress(TEST_HOSTNAME, TEST_PORT).usePlaintext(true).build();
+    DgraphGrpc.DgraphBlockingStub blockingStub = DgraphGrpc.newBlockingStub(channel);
+    dgraphClient = new DgraphClient(Collections.singletonList(blockingStub), 1);
+
+    Operation op = Operation.newBuilder().setSchema("name: string @index(exact) .").build();
+
+    // Alters schema without exceeding the given deadline.
+    dgraphClient.alter(op);
+
+    // Creates a blocking stub directly, in order to force a deadline to be exceeded.
+    Method method = DgraphClient.class.getDeclaredMethod("anyClient");
+    method.setAccessible(true);
+
+    DgraphGrpc.DgraphBlockingStub client =
+        (DgraphGrpc.DgraphBlockingStub) method.invoke(dgraphClient, null);
+
+    Thread.sleep(1001);
+
+    try {
+      client.alter(op);
+      fail("Deadline should have been exceeded");
+    } catch (StatusRuntimeException sre) {
+      // Expected.
     }
   }
 }


### PR DESCRIPTION
Sometimes there's a need to invoke a RPC call with timeouts, or rather, a deadline for quality of service.

When a cluster node was unresponsive, the call/stack gets blocked waiting for the reply. A deadline should mitigate this possibility.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph4j/48)
<!-- Reviewable:end -->
