### PR TITLE
Added the doc and sample code for setting metadata headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ and understand how to run and work with Dgraph.
   * [Run a query](#run-a-query)
   * [Commit a transaction](#commit-a-transaction)
   * [Setting Deadlines](#setting-deadlines)
+  * [Setting Metadata Headers](#setting-metedata-headers)
   * [Helper Methods](#helper-methods)
 * [Using the Asynchronous Client](#using-the-asynchronous-client)
 - [Development](#development)
@@ -264,6 +265,25 @@ DgraphClient dgraphClient = new DgraphClient(stub);
 
 [deadline-post]: https://discuss.dgraph.io/t/dgraph-java-client-setting-deadlines-per-call/3056
 
+### Setting Metadata Headers
+Certain headers such as authentication tokens need to be set globally for all subsequent calls.
+Below is an example of setting a header with the name "auth-token":
+```java
+// create the stub first
+ManagedChannel channel = ManagedChannelBuilder.forAddress(TEST_HOSTNAME, TEST_PORT).usePlaintext(true).build();
+DgraphStub stub = DgraphGrpc.newStub(channel);
+
+// use MetadataUtils to augment the stub with headers
+Metadata metadata = new Metadata();
+metadata.put(Metadata.Key.of("auth-token", Metadata.ASCII_STRING_MARSHALLER), "the-auth-token-value");
+stub = MetadataUtils.attachHeaders(stub, metadata);
+
+// create the DgraphClient wrapper around the stub
+DgraphClient dgraphClient = new DgraphClient(stub);
+
+// trigger a RPC call using the DgraphClient
+dgraphClient.alter(Operation.newBuilder().setDropAll(true).build());
+```
 ### Helper Methods
 
 #### Delete multiple edges

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ and understand how to run and work with Dgraph.
   * [Run a query](#run-a-query)
   * [Commit a transaction](#commit-a-transaction)
   * [Setting Deadlines](#setting-deadlines)
-  * [Setting Metadata Headers](#setting-metedata-headers)
+  * [Setting Metadata Headers](#setting-metadata-headers)
   * [Helper Methods](#helper-methods)
 * [Using the Asynchronous Client](#using-the-asynchronous-client)
 - [Development](#development)

--- a/samples/DgraphJavaSample/src/main/java/App.java
+++ b/samples/DgraphJavaSample/src/main/java/App.java
@@ -9,6 +9,9 @@ import io.dgraph.DgraphProto.Response;
 import io.dgraph.Transaction;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.stub.MetadataUtils;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -21,6 +24,11 @@ public class App {
     ManagedChannel channel =
         ManagedChannelBuilder.forAddress(TEST_HOSTNAME, TEST_PORT).usePlaintext(true).build();
     DgraphStub stub = DgraphGrpc.newStub(channel);
+
+    Metadata metadata = new Metadata();
+    metadata.put(Metadata.Key.of("auth-token", Metadata.ASCII_STRING_MARSHALLER), "the-auth-token-value");
+    stub = MetadataUtils.attachHeaders(stub, metadata);
+
     DgraphClient dgraphClient = new DgraphClient(stub);
 
     // Initialize

--- a/samples/DgraphJavaSample/src/main/java/App.java
+++ b/samples/DgraphJavaSample/src/main/java/App.java
@@ -20,16 +20,22 @@ public class App {
   private static final String TEST_HOSTNAME = "localhost";
   private static final int TEST_PORT = 9080;
 
-  public static void main(final String[] args) {
+  private static DgraphClient createDgraphClient(boolean withAuthHeader) {
     ManagedChannel channel =
-        ManagedChannelBuilder.forAddress(TEST_HOSTNAME, TEST_PORT).usePlaintext(true).build();
+            ManagedChannelBuilder.forAddress(TEST_HOSTNAME, TEST_PORT).usePlaintext(true).build();
     DgraphStub stub = DgraphGrpc.newStub(channel);
 
-    Metadata metadata = new Metadata();
-    metadata.put(Metadata.Key.of("auth-token", Metadata.ASCII_STRING_MARSHALLER), "the-auth-token-value");
-    stub = MetadataUtils.attachHeaders(stub, metadata);
+    if (withAuthHeader) {
+      Metadata metadata = new Metadata();
+      metadata.put(Metadata.Key.of("auth-token", Metadata.ASCII_STRING_MARSHALLER), "the-auth-token-value");
+      stub = MetadataUtils.attachHeaders(stub, metadata);
+    }
 
-    DgraphClient dgraphClient = new DgraphClient(stub);
+    return new DgraphClient(stub);
+  }
+
+  public static void main(final String[] args) {
+    DgraphClient dgraphClient = createDgraphClient(false);
 
     // Initialize
     dgraphClient.alter(Operation.newBuilder().setDropAll(true).build());


### PR DESCRIPTION
Tested the code by
1. setting up a dgraph cluster with alpha servers running with the "--auth_token the-auth-token-value" option
2.a if the sample code does not have the auth-token header set, then the alter operation would run into an error complaining about missing auth-token
2.b after the auth-token metadata header is set, all the RPC calls work successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph4j/70)
<!-- Reviewable:end -->
