### PR TITLE
Build shadow jar relocating dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ plugins {
     id 'jacoco'
     id 'com.github.kt3k.coveralls' version '2.8.2'
     id 'com.github.sherter.google-java-format' version '0.8'
+    id 'com.github.johnrengelman.shadow' version '5.0.0'
 }
 // Apply the java plugin to add support for Java
 apply plugin: 'java'
@@ -38,6 +39,7 @@ apply plugin: 'idea'
 apply plugin: 'com.github.sherter.google-java-format'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 group = 'io.dgraph'
 archivesBaseName = 'dgraph4j'
@@ -49,6 +51,11 @@ def grpcVersion = '1.22.1'
 def dgraph4jVersion = "$version"
 def openCensusVersion = '0.23.0'
 
+// Output to build/libs/shadow.jar
+shadowJar {
+    classifier = 'shadow'
+    relocate 'com.google.common', 'io.dgraph.shaded.com.google.common'
+}
 
 protobuf {
     protoc {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-all.zip

--- a/samples/DgraphJavaSample/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/DgraphJavaSample/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip

--- a/samples/DgraphJavaSample/settings.gradle
+++ b/samples/DgraphJavaSample/settings.gradle
@@ -5,7 +5,7 @@
  * In a single project build this file can be empty or even removed.
  *
  * Detailed information about configuring a multi-project build in Gradle can be found
- * in the user guide at https://docs.gradle.org/4.3/userguide/multi_project_builds.html
+ * in the user guide at https://docs.gradle.org/5.0/userguide/multi_project_builds.html
  */
 
 /*


### PR DESCRIPTION
Fixes #84

Todo -
 * [ ] Publish shadow jar on maven central
 * [x] Shadow grpc dependency => Not doing it, this could cause issues because the project using Dgraph4J will have a direct dependency on grpc libraries, given that it is create channels using ManagedBuilder etc.
 * [x] Reduce the size of shadow jar => it is 13 MB now

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph4j/85)
<!-- Reviewable:end -->
