### PR TITLE
best effort method in Transaction

### DIFF
--- a/src/main/java/io/dgraph/Transaction.java
+++ b/src/main/java/io/dgraph/Transaction.java
@@ -110,6 +110,15 @@ public class Transaction implements AutoCloseable {
         });
   }
 
+  /**
+   * Sets the best effort flag for this transaction. The Best effort flag can only be set for
+   * read-only transactions, and setting the best effort flag will enable a read-only transaction to
+   * see mutations made by other transactions even if those mutations have not been committed.
+   */
+  public void setBestEffort(boolean bestEffort) {
+    asyncTransaction.setBestEffort(bestEffort);
+  }
+
   @Override
   public void close() {
     ExceptionUtil.withExceptionUnwrapped(this::discard);


### PR DESCRIPTION
Details: Added best effort method to the transaction class to call the AsyncTransaction class method.

Need: Method in AsyncTransaction is not exposed through Transaction class, using the method for bestEfforts as per https://github.com/dgraph-io/dgraph4j#create-a-transaction is not feasible, which needs it to be exposed through Transaction class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph4j/86)
<!-- Reviewable:end -->
