### PR TITLE
Moving the dependency io.opencensus.* into a test dependency only,

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,13 +41,13 @@ apply plugin: 'signing'
 
 group = 'io.dgraph'
 archivesBaseName = 'dgraph4j'
-version = '1.7.4'
+version = '1.7.5'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 def grpcVersion = '1.15.1'
 def dgraph4jVersion = "$version"
-def openCensusVersion = '0.17.0'
+def openCensusVersion = '0.23.0'
 
 
 protobuf {
@@ -108,9 +108,9 @@ dependencies {
     compile "io.grpc:grpc-netty:${grpcVersion}"
 	compile "io.grpc:grpc-stub:${grpcVersion}"
 
-    compile "io.opencensus:opencensus-api:${openCensusVersion}"
-    compile "io.opencensus:opencensus-exporter-trace-jaeger:${openCensusVersion}"
-    runtime "io.opencensus:opencensus-impl:${openCensusVersion}"
+    testCompile "io.opencensus:opencensus-api:${openCensusVersion}"
+    testCompile "io.opencensus:opencensus-exporter-trace-jaeger:${openCensusVersion}"
+    testRuntime "io.opencensus:opencensus-impl:${openCensusVersion}"
 
     // Declare the dependency for your favourite test framework you want to use in your tests.
     testCompile 'org.testng:testng:6.8.8'

--- a/src/test/java/io/dgraph/UpsertBlockTest.java
+++ b/src/test/java/io/dgraph/UpsertBlockTest.java
@@ -1,97 +1,102 @@
 package io.dgraph;
 
+import static org.testng.Assert.assertEquals;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.protobuf.ByteString;
-import org.testng.annotations.Test;
 import io.dgraph.DgraphProto.*;
-
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import org.testng.annotations.Test;
 
 public class UpsertBlockTest extends DgraphIntegrationTest {
-    @Test
-    public void upsertBlockTest() throws Exception {
-        DgraphProto.Operation op =
-                DgraphProto.Operation.newBuilder()
-                        .setSchema("email: string @index(exact) @upsert .").build();
-        dgraphClient.alter(op);
+  @Test
+  public void upsertBlockTest() throws Exception {
+    DgraphProto.Operation op =
+        DgraphProto.Operation.newBuilder()
+            .setSchema("email: string @index(exact) @upsert .")
+            .build();
+    dgraphClient.alter(op);
 
-        String query = "" +
-                "{\n" +
-                "    me(func: eq(email, \"ashish@dgraph.io\")) {\n" +
-                "        v as uid\n" +
-                "    }\n" +
-                "}\n";
+    String query =
+        ""
+            + "{\n"
+            + "    me(func: eq(email, \"ashish@dgraph.io\")) {\n"
+            + "        v as uid\n"
+            + "    }\n"
+            + "}\n";
 
-        JsonArray jA = new JsonArray();
-        JsonObject p1 = new JsonObject();
-        p1.addProperty("uid", "uid(v)");
-        p1.addProperty("name", "wrong");
-        jA.add(p1);
+    JsonArray jA = new JsonArray();
+    JsonObject p1 = new JsonObject();
+    p1.addProperty("uid", "uid(v)");
+    p1.addProperty("name", "wrong");
+    jA.add(p1);
 
-        JsonObject p2 = new JsonObject();
-        p2.addProperty("email", "ashish@dgraph.io");
-        p2.addProperty("uid", "uid(v)");
-        jA.add(p2);
+    JsonObject p2 = new JsonObject();
+    p2.addProperty("email", "ashish@dgraph.io");
+    p2.addProperty("uid", "uid(v)");
+    jA.add(p2);
 
-        Mutation mu = Mutation.newBuilder()
-                .setQuery(query)
-                .setSetJson(ByteString.copyFromUtf8(jA.toString()))
-                .build();
+    Mutation mu =
+        Mutation.newBuilder()
+            .setQuery(query)
+            .setSetJson(ByteString.copyFromUtf8(jA.toString()))
+            .build();
 
-        Transaction txn = dgraphClient.newTransaction();
-        txn.mutate(mu);
-        txn.commit();
+    Transaction txn = dgraphClient.newTransaction();
+    txn.mutate(mu);
+    txn.commit();
 
-        String query2 = "" +
-                "{\n" +
-                "    me(func: eq(email, \"ashish@dgraph.io\")) {\n" +
-                "        name\n" +
-                "        email\n" +
-                "    }\n" +
-                "}\n";
+    String query2 =
+        ""
+            + "{\n"
+            + "    me(func: eq(email, \"ashish@dgraph.io\")) {\n"
+            + "        name\n"
+            + "        email\n"
+            + "    }\n"
+            + "}\n";
 
-        txn = dgraphClient.newTransaction();
-        Response response = txn.query(query2);
-        String res = response.getJson().toStringUtf8();
-        String exp1 = "{\"me\":[{\"name\":\"wrong\",\"email\":\"ashish@dgraph.io\"}]}";
-        assertEquals(res, exp1);
+    txn = dgraphClient.newTransaction();
+    Response response = txn.query(query2);
+    String res = response.getJson().toStringUtf8();
+    String exp1 = "{\"me\":[{\"name\":\"wrong\",\"email\":\"ashish@dgraph.io\"}]}";
+    assertEquals(res, exp1);
 
-        jA = new JsonArray();
-        p1 = new JsonObject();
-        p1.addProperty("uid", "uid(v)");
-        p1.addProperty("name", "ashish");
-        jA.add(p1);
+    jA = new JsonArray();
+    p1 = new JsonObject();
+    p1.addProperty("uid", "uid(v)");
+    p1.addProperty("name", "ashish");
+    jA.add(p1);
 
-        mu = Mutation.newBuilder()
-                .setQuery(query)
-                .setSetJson(ByteString.copyFromUtf8(jA.toString()))
-                .build();
+    mu =
+        Mutation.newBuilder()
+            .setQuery(query)
+            .setSetJson(ByteString.copyFromUtf8(jA.toString()))
+            .build();
 
-        txn = dgraphClient.newTransaction();
-        txn.mutate(mu);
-        txn.commit();
+    txn = dgraphClient.newTransaction();
+    txn.mutate(mu);
+    txn.commit();
 
-        txn = dgraphClient.newTransaction();
-        response = txn.query(query2);
-        res = response.getJson().toStringUtf8();
-        String exp2 = "{\"me\":[{\"name\":\"ashish\",\"email\":\"ashish@dgraph.io\"}]}";
-        assertEquals(res, exp2);
+    txn = dgraphClient.newTransaction();
+    response = txn.query(query2);
+    res = response.getJson().toStringUtf8();
+    String exp2 = "{\"me\":[{\"name\":\"ashish\",\"email\":\"ashish@dgraph.io\"}]}";
+    assertEquals(res, exp2);
 
-        mu = Mutation.newBuilder()
-                .setQuery(query)
-                .setDelNquads(ByteString.copyFromUtf8("uid(v) <name> * .\nuid(v) <email> * ."))
-                .build();
+    mu =
+        Mutation.newBuilder()
+            .setQuery(query)
+            .setDelNquads(ByteString.copyFromUtf8("uid(v) <name> * .\nuid(v) <email> * ."))
+            .build();
 
-        txn = dgraphClient.newTransaction();
-        txn.mutate(mu);
-        txn.commit();
+    txn = dgraphClient.newTransaction();
+    txn.mutate(mu);
+    txn.commit();
 
-        txn = dgraphClient.newTransaction();
-        response = txn.query(query2);
-        res = response.getJson().toStringUtf8();
-        String exp3 = "{\"me\":[]}";
-        assertEquals(res, exp3);
-    }
+    txn = dgraphClient.newTransaction();
+    response = txn.query(query2);
+    res = response.getJson().toStringUtf8();
+    String exp3 = "{\"me\":[]}";
+    assertEquals(res, exp3);
+  }
 }


### PR DESCRIPTION
to avoid excessive CPU usage reported in
https://github.com/census-instrumentation/opencensus-java/issues/1599

PS: the changes in the UpsertBlockTest.java file are the result of running google format, and there is no logic changes at all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph4j/89)
<!-- Reviewable:end -->
