### PR TITLE
Upgrade grpc to get rid of Java 11 warnings from grpc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ version = '1.7.5'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-def grpcVersion = '1.15.1'
+def grpcVersion = '1.22.1'
 def dgraph4jVersion = "$version"
 def openCensusVersion = '0.23.0'
 


### PR DESCRIPTION
```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.protobuf.UnsafeUtil (file:/Users/user/whatever/some-program-0.1.0-SNAPSHOT-standalone.jar) to field java.nio.Buffer.address
WARNING: Please consider reporting this to the maintainers of com.google.protobuf.UnsafeUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```

Fixed at https://github.com/protocolbuffers/protobuf/commit/624a40a387e1b2da4c6bbde44ad3d0a5efb9879b#diff-6c9e043b78f78efc096211703bb7fa4a

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph4j/94)
<!-- Reviewable:end -->
