### PR TITLE
README: Add connection disconnect docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ and understand how to run and work with Dgraph.
   * [Setting Deadlines](#setting-deadlines)
   * [Setting Metadata Headers](#setting-metadata-headers)
   * [Helper Methods](#helper-methods)
+  * [Close the DB Connection](#close-the-db-connection)
 * [Using the Asynchronous Client](#using-the-asynchronous-client)
 * [Checking the request latency](#checking-the-request-latency)
 - [Development](#development)
@@ -363,6 +364,16 @@ with the deletions applied.
  Mutation mu = Mutation.newBuilder().build()
  mu = Helpers.deleteEdges(mu, uid, "friends", "loc");
  dgraphClient.newTransaction().mutate(mu);
+```
+
+### Close the DB Connection
+
+To disconnect from Dgraph, call `ManagedChannel#shutdown` on the gRPC
+channel object created when [creating the Dgraph
+client](#create-the-client).
+
+```
+channel.shutdown();
 ```
 
 ## Using the Asynchronous Client

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ and understand how to run and work with Dgraph.
   * [Setting Deadlines](#setting-deadlines)
   * [Setting Metadata Headers](#setting-metadata-headers)
   * [Helper Methods](#helper-methods)
-  * [Close the DB Connection](#close-the-db-connection)
+  * [Closing the DB Connection](#closing-the-db-connection)
 * [Using the Asynchronous Client](#using-the-asynchronous-client)
 * [Checking the request latency](#checking-the-request-latency)
 - [Development](#development)
@@ -366,11 +366,11 @@ with the deletions applied.
  dgraphClient.newTransaction().mutate(mu);
 ```
 
-### Close the DB Connection
+### Closing the DB Connection
 
 To disconnect from Dgraph, call `ManagedChannel#shutdown` on the gRPC
 channel object created when [creating the Dgraph
-client](#create-the-client).
+client](#creating-the-client).
 
 ```
 channel.shutdown();

--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ be found in the [Using the Asynchronous Client](#using-the-asynchronous-client) 
 The following code snippet shows how to create a synchronous client using just one connection.
 
 ```java
-ManagedChannel channel =
-ManagedChannelBuilder.forAddress("localhost", 9080).usePlaintext(true).build();
+ManagedChannel channel = ManagedChannelBuilder
+    .forAddress("localhost", 9080)
+    .usePlaintext(true).build();
 DgraphStub stub = DgraphGrpc.newStub(channel);
 DgraphClient dgraphClient = new DgraphClient(Collections.singletonList(stub));
 ```
@@ -369,8 +370,8 @@ with the deletions applied.
 ### Closing the DB Connection
 
 To disconnect from Dgraph, call `ManagedChannel#shutdown` on the gRPC
-channel object created when [creating the Dgraph
-client](#creating-the-client).
+channel object created when [creating a Dgraph
+client](#creating-a-client).
 
 ```
 channel.shutdown();


### PR DESCRIPTION
Similar to how to close the connection over gRPC in the dgo client,
dgraph4j can disconnect from Dgraph by closing the gRPC connection
using `ManagedChannel#shutdown`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph4j/98)
<!-- Reviewable:end -->
