### PR TITLE
Fix Opencensus tracing.

### DIFF
--- a/src/main/java/io/dgraph/AsyncTransaction.java
+++ b/src/main/java/io/dgraph/AsyncTransaction.java
@@ -20,9 +20,12 @@ import io.dgraph.DgraphProto.Mutation;
 import io.dgraph.DgraphProto.Request;
 import io.dgraph.DgraphProto.Response;
 import io.dgraph.DgraphProto.TxnContext;
+import io.grpc.Context;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 /**
  * This is the implementation of asynchronous Dgraph transaction. The asynchrony is backed-up by
@@ -147,24 +150,35 @@ public class AsyncTransaction implements AutoCloseable {
       mutated = true;
     }
 
+    final Callable<CompletableFuture<Response>> callable =
+        Context.current()
+            .wrap(
+                () -> {
+                  StreamObserverBridge<Response> bridge = new StreamObserverBridge<>();
+                  DgraphStub localStub = client.getStubWithJwt(stub);
+                  localStub.query(request, bridge);
+
+                  return bridge
+                      .getDelegate()
+                      .thenApply(
+                          (response) -> {
+                            if (request.getCommitNow()) {
+                              finished = true;
+                            }
+                            mergeContext(response.getTxn());
+                            return response;
+                          });
+                });
+
     return client
         .runWithRetries(
             "doRequest",
             () -> {
-              StreamObserverBridge<Response> bridge = new StreamObserverBridge<>();
-              DgraphStub localStub = client.getStubWithJwt(stub);
-              localStub.query(request, bridge);
-
-              return bridge
-                  .getDelegate()
-                  .thenApply(
-                      (response) -> {
-                        if (request.getCommitNow()) {
-                          finished = true;
-                        }
-                        mergeContext(response.getTxn());
-                        return response;
-                      });
+              try {
+                return callable.call();
+              } catch (Exception e) {
+                throw new CompletionException(e);
+              }
             })
         .handle(
             (Response response, Throwable throwable) -> {
@@ -201,13 +215,24 @@ public class AsyncTransaction implements AutoCloseable {
       return CompletableFuture.completedFuture(null);
     }
 
+    final Callable<CompletableFuture<Void>> callable =
+        Context.current()
+            .wrap(
+                () -> {
+                  StreamObserverBridge<TxnContext> bridge = new StreamObserverBridge<>();
+                  DgraphStub localStub = client.getStubWithJwt(stub);
+                  localStub.commitOrAbort(context, bridge);
+                  return bridge.getDelegate().thenApply(txnContext -> null);
+                });
+
     return client.runWithRetries(
         "commit",
         () -> {
-          StreamObserverBridge<TxnContext> bridge = new StreamObserverBridge<>();
-          DgraphStub localStub = client.getStubWithJwt(stub);
-          localStub.commitOrAbort(context, bridge);
-          return bridge.getDelegate().thenApply(txnContext -> null);
+          try {
+            return callable.call();
+          } catch (Exception e) {
+            throw new CompletionException(e);
+          }
         });
   }
 
@@ -232,13 +257,24 @@ public class AsyncTransaction implements AutoCloseable {
     }
 
     context = TxnContext.newBuilder(context).setAborted(true).build();
+    final Callable<CompletableFuture<Void>> callable =
+        Context.current()
+            .wrap(
+                () -> {
+                  StreamObserverBridge<TxnContext> bridge = new StreamObserverBridge<>();
+                  DgraphStub localStub = client.getStubWithJwt(stub);
+                  localStub.commitOrAbort(context, bridge);
+                  return bridge.getDelegate().thenApply((o) -> null);
+                });
+
     return client.runWithRetries(
         "discard",
         () -> {
-          StreamObserverBridge<TxnContext> bridge = new StreamObserverBridge<>();
-          DgraphStub localStub = client.getStubWithJwt(stub);
-          localStub.commitOrAbort(context, bridge);
-          return bridge.getDelegate().thenApply((o) -> null);
+          try {
+            return callable.call();
+          } catch (Exception e) {
+            throw new CompletionException(e);
+          }
         });
   }
 

--- a/src/test/java/io/dgraph/OpencensusJaegerTest.java
+++ b/src/test/java/io/dgraph/OpencensusJaegerTest.java
@@ -37,8 +37,7 @@ public class OpencensusJaegerTest extends DgraphIntegrationTest {
     txn.mutate(mu);
     txn.commit();
 
-    String query =
-        "{\n" + "  q(func: eq(name, \"Alice\")) {\n" + "    name\n" + "    uid\n" + "  }\n" + "}";
+    String query = "{\n q(func: eq(name, \"Alice\")) {\n name\n uid\n}\n}";
     dgraphClient.newTransaction().query(query);
   }
 

--- a/src/test/java/io/dgraph/OpencensusJaegerTest.java
+++ b/src/test/java/io/dgraph/OpencensusJaegerTest.java
@@ -30,10 +30,16 @@ public class OpencensusJaegerTest extends DgraphIntegrationTest {
 
     DgraphProto.Mutation mu =
         DgraphProto.Mutation.newBuilder()
-            .setCommitNow(true)
+            .setCommitNow(false)
             .setSetJson(ByteString.copyFromUtf8(jsonData.toString()))
             .build();
-    dgraphClient.newTransaction().mutate(mu);
+    Transaction txn = dgraphClient.newTransaction();
+    txn.mutate(mu);
+    txn.commit();
+
+    String query =
+        "{\n" + "  q(func: eq(name, \"Alice\")) {\n" + "    name\n" + "    uid\n" + "  }\n" + "}";
+    dgraphClient.newTransaction().query(query);
   }
 
   @Test
@@ -52,7 +58,8 @@ public class OpencensusJaegerTest extends DgraphIntegrationTest {
 
     // 4. Create a scoped span, a scoped span will automatically end when closed.
     // It implements AutoClosable, so it'll be closed when the try block ends.
-    try (Scope ignored = tracer.spanBuilder("query").startScopedSpan()) {
+    try (Scope ignored = tracer.spanBuilder("test-span").startScopedSpan()) {
+      tracer.getCurrentSpan().addAnnotation("test annotation");
       runTransactions();
     }
 


### PR DESCRIPTION
When passing a lambda to runWithRetries, the grpc context is lost,
causing spans in OpenCensus to become disconnected. This PR fixes the
issue by calling the wrap function in the grpc library, which wraps a
callable with the appropriate context so that it's propagated all the
way throughout.

The OpenCensus test is also changed to include the use of the query and
commit endpoints for more thorough testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph4j/117)
<!-- Reviewable:end -->
