### PR TITLE
Fix slf4j dependencies.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,10 +103,12 @@ configurations {
 dependencies {
     // The production code uses the SLF4J logging API at compile time
     compile "org.slf4j:slf4j-api:1.7.21"
-    compile "org.slf4j:slf4j-simple:1.7.21"
-	compile "io.grpc:grpc-protobuf:${grpcVersion}"
+    // Specific slf4j bindings should not be included in the default (compile) scope.
+    // See http://www.slf4j.org/faq.html#maven2.
+    testCompile "org.slf4j:slf4j-simple:1.7.21"
+    compile "io.grpc:grpc-protobuf:${grpcVersion}"
     compile "io.grpc:grpc-netty:${grpcVersion}"
-	compile "io.grpc:grpc-stub:${grpcVersion}"
+    compile "io.grpc:grpc-stub:${grpcVersion}"
 
     testCompile "io.opencensus:opencensus-api:${openCensusVersion}"
     testCompile "io.opencensus:opencensus-exporter-trace-jaeger:${openCensusVersion}"


### PR DESCRIPTION
The bindings to slf4j-simple should not be part of the compile-time
dependencies. Otherwise, users of dgraph4j experience errors if they
have their own bindings in their projects.

Fixes #131

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph4j/133)
<!-- Reviewable:end -->
