### PR TITLE
Update Java version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ use a different version of this client.
 
 | Dgraph version | dgraph4j version  | java version |
 |:--------------:|:-----------------:|:------------:|
-|     1.0.X      |       1.X.X       |     1.8.X    |
-|    >= 1.1.0    |       2.X.X       |     1.8.X    |
+|     1.0.X      |       1.X.X       |     1.9.X    |
+|    >= 1.1.0    |       2.X.X       |     1.9.X    |
 
 ## Quickstart
 Build and run the [DgraphJavaSample] project in the `samples` folder, which


### PR DESCRIPTION
Quoting [gRPC documentation](https://github.com/grpc/grpc-java/blob/master/SECURITY.md#tls-on-non-android) for TLS on non-Android platforms:
> JDK versions prior to Java 9 do not support ALPN and are either missing AES GCM support or have 2% the performance of OpenSSL.

Fixes #142.
Fixes #CLIENTS-105.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph4j/143)
<!-- Reviewable:end -->
