### PR TITLE
Delete argument from method usePlainText

### DIFF
--- a/samples/DgraphJavaSample/src/main/java/App.java
+++ b/samples/DgraphJavaSample/src/main/java/App.java
@@ -21,7 +21,7 @@ public class App {
 
   private static DgraphClient createDgraphClient(boolean withAuthHeader) {
     ManagedChannel channel =
-        ManagedChannelBuilder.forAddress(TEST_HOSTNAME, TEST_PORT).usePlaintext(true).build();
+        ManagedChannelBuilder.forAddress(TEST_HOSTNAME, TEST_PORT).usePlaintext().build();
     DgraphStub stub = DgraphGrpc.newStub(channel);
 
     if (withAuthHeader) {


### PR DESCRIPTION
According to the documentation, usePlainText() does not accept arguments https://grpc.github.io/grpc-java/javadoc/io/grpc/ManagedChannelBuilder.html#usePlaintext--

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph4j/148)
<!-- Reviewable:end -->
