### PR TITLE
Allow creation of Transaction/AsyncTransaction from TxnContext

### DIFF
--- a/src/main/java/io/dgraph/AsyncTransaction.java
+++ b/src/main/java/io/dgraph/AsyncTransaction.java
@@ -52,6 +52,11 @@ public class AsyncTransaction implements AutoCloseable {
     this.bestEffort = false;
   }
 
+  AsyncTransaction(DgraphAsyncClient client, DgraphStub stub, final boolean readOnly) {
+    this(client, stub);
+    this.readOnly = readOnly;
+  }
+
   AsyncTransaction(DgraphAsyncClient client, DgraphStub stub, TxnContext context) {
     this(client, stub);
     this.context = context;
@@ -61,11 +66,6 @@ public class AsyncTransaction implements AutoCloseable {
       DgraphAsyncClient client, DgraphStub stub, TxnContext context, final boolean readOnly) {
     this(client, stub, context);
     this.context = context;
-    this.readOnly = readOnly;
-  }
-
-  AsyncTransaction(DgraphAsyncClient client, DgraphStub stub, final boolean readOnly) {
-    this(client, stub);
     this.readOnly = readOnly;
   }
 

--- a/src/main/java/io/dgraph/AsyncTransaction.java
+++ b/src/main/java/io/dgraph/AsyncTransaction.java
@@ -52,6 +52,18 @@ public class AsyncTransaction implements AutoCloseable {
     this.bestEffort = false;
   }
 
+  AsyncTransaction(DgraphAsyncClient client, DgraphStub stub, TxnContext context) {
+    this(client, stub);
+    this.context = context;
+  }
+
+  AsyncTransaction(
+      DgraphAsyncClient client, DgraphStub stub, TxnContext context, final boolean readOnly) {
+    this(client, stub, context);
+    this.context = context;
+    this.readOnly = readOnly;
+  }
+
   AsyncTransaction(DgraphAsyncClient client, DgraphStub stub, final boolean readOnly) {
     this(client, stub);
     this.readOnly = readOnly;

--- a/src/main/java/io/dgraph/DgraphAsyncClient.java
+++ b/src/main/java/io/dgraph/DgraphAsyncClient.java
@@ -19,6 +19,7 @@ import static java.util.Arrays.asList;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.dgraph.DgraphProto.Payload;
+import io.dgraph.DgraphProto.TxnContext;
 import io.grpc.Context;
 import io.grpc.Metadata;
 import io.grpc.Status;
@@ -271,6 +272,27 @@ public class DgraphAsyncClient {
   }
 
   /**
+   * Creates a new AsyncTransaction object from a TxnContext. All operations performed by this
+   * transaction are asynchronous.
+   *
+   * <p>A transaction lifecycle is as follows:
+   *
+   * <p>- Created using AsyncTransaction#newTransaction()
+   *
+   * <p>- Various AsyncTransaction#query() and AsyncTransaction#mutate() calls made.
+   *
+   * <p>- Commit using AsyncTransacation#commit() or Discard using AsyncTransaction#discard(). If
+   * any mutations have been made, It's important that at least one of these methods is called to
+   * clean up resources. Discard is a no-op if Commit has already been called, so it's safe to call
+   * it after Commit.
+   *
+   * @return a new AsyncTransaction object.
+   */
+  public AsyncTransaction newTransaction(TxnContext context) {
+    return new AsyncTransaction(this, this.anyClient(), context);
+  }
+
+  /**
    * Creates a new AsyncTransaction object that only allows queries. Any AsyncTransaction#mutate()
    * or AsyncTransaction#commit() call made to the read only transaction will result in
    * TxnReadOnlyException. All operations performed by this transaction are asynchronous.
@@ -279,5 +301,17 @@ public class DgraphAsyncClient {
    */
   public AsyncTransaction newReadOnlyTransaction() {
     return new AsyncTransaction(this, this.anyClient(), true);
+  }
+
+  /**
+   * Creates a new AsyncTransaction object from a TnxContext that only allows queries. Any
+   * AsyncTransaction#mutate() or AsyncTransaction#commit() call made to the read only transaction
+   * will result in TxnReadOnlyException. All operations performed by this transaction are
+   * asynchronous.
+   *
+   * @return a new AsyncTransaction object
+   */
+  public AsyncTransaction newReadOnlyTransaction(TxnContext context) {
+    return new AsyncTransaction(this, this.anyClient(), context, true);
   }
 }

--- a/src/main/java/io/dgraph/DgraphClient.java
+++ b/src/main/java/io/dgraph/DgraphClient.java
@@ -16,6 +16,7 @@
 package io.dgraph;
 
 import io.dgraph.DgraphProto.Operation;
+import io.dgraph.DgraphProto.TxnContext;
 
 /**
  * Implementation of a DgraphClient using grpc.
@@ -63,6 +64,27 @@ public class DgraphClient {
   }
 
   /**
+   * Creates a new Transaction object from a TxnContext. All operations performed by this
+   * transaction are synchronous.
+   *
+   * <p>A transaction lifecycle is as follows:
+   *
+   * <p>- Created using AsyncTransaction#newTransaction()
+   *
+   * <p>- Various AsyncTransaction#query() and AsyncTransaction#mutate() calls made.
+   *
+   * <p>- Commit using Transacation#commit() or Discard using AsyncTransaction#discard(). If any
+   * mutations have been made, It's important that at least one of these methods is called to clean
+   * up resources. Discard is a no-op if Commit has already been called, so it's safe to call it
+   * after Commit.
+   *
+   * @return a new Transaction object.
+   */
+  public Transaction newTransaction(TxnContext context) {
+    return new Transaction(asyncClient.newTransaction(context));
+  }
+
+  /**
    * Creates a new AsyncTransaction object that only allows queries. Any Transaction#mutate() or
    * Transaction#commit() call made to the read only transaction will result in
    * TxnReadOnlyException. All operations performed by this transaction are synchronous.
@@ -71,6 +93,17 @@ public class DgraphClient {
    */
   public Transaction newReadOnlyTransaction() {
     return new Transaction(asyncClient.newReadOnlyTransaction());
+  }
+
+  /**
+   * Creates a new AsyncTransaction object from a TnxContext that only allows queries. Any
+   * Transaction#mutate() or Transaction#commit() call made to the read only transaction will result
+   * in TxnReadOnlyException. All operations performed by this transaction are synchronous.
+   *
+   * @return a new AsyncTransaction object
+   */
+  public Transaction newReadOnlyTransaction(TxnContext context) {
+    return new Transaction(asyncClient.newReadOnlyTransaction(context));
   }
 
   /**

--- a/src/test/java/io/dgraph/DgraphAsyncClientTest.java
+++ b/src/test/java/io/dgraph/DgraphAsyncClientTest.java
@@ -106,19 +106,19 @@ public class DgraphAsyncClientTest {
   }
 
   @Test
-  public void testNewTransactionFromContext() throws Exception {
+  public void testNewTransactionFromContext() {
     DgraphProto.TxnContext ctx = DgraphProto.TxnContext.newBuilder().setStartTs(1234L).build();
     try (AsyncTransaction txn = dgraphAsyncClient.newTransaction(ctx)) {
-      Response response = txn.query("{ result(func: uid(0x0)) { } }").get();
+      Response response = txn.query("{ result(func: uid(0x1)) { } }").join();
       assertEquals(response.getTxn().getStartTs(), 1234L);
     }
   }
 
   @Test
-  public void testNewReadOnlyTransactionFromContext() throws Exception {
+  public void testNewReadOnlyTransactionFromContext() {
     DgraphProto.TxnContext ctx = DgraphProto.TxnContext.newBuilder().setStartTs(1234L).build();
     try (AsyncTransaction txn = dgraphAsyncClient.newReadOnlyTransaction(ctx)) {
-      Response response = txn.query("{ result(func: uid(0x0)) { } }").get();
+      Response response = txn.query("{ result(func: uid(0x1)) { } }").join();
       assertEquals(response.getTxn().getStartTs(), 1234L);
     }
   }

--- a/src/test/java/io/dgraph/DgraphAsyncClientTest.java
+++ b/src/test/java/io/dgraph/DgraphAsyncClientTest.java
@@ -105,6 +105,24 @@ public class DgraphAsyncClientTest {
     }
   }
 
+  @Test
+  public void testNewTransactionFromContext() throws Exception {
+    DgraphProto.TxnContext ctx = DgraphProto.TxnContext.newBuilder().setStartTs(1234L).build();
+    try (AsyncTransaction txn = dgraphAsyncClient.newTransaction(ctx)) {
+      Response response = txn.query("{ result(func: uid(0x0)) { } }").get();
+      assertEquals(response.getTxn().getStartTs(), 1234L);
+    }
+  }
+
+  @Test
+  public void testNewReadOnlyTransactionFromContext() throws Exception {
+    DgraphProto.TxnContext ctx = DgraphProto.TxnContext.newBuilder().setStartTs(1234L).build();
+    try (AsyncTransaction txn = dgraphAsyncClient.newReadOnlyTransaction(ctx)) {
+      Response response = txn.query("{ result(func: uid(0x0)) { } }").get();
+      assertEquals(response.getTxn().getStartTs(), 1234L);
+    }
+  }
+
   @Test(expectedExceptions = TxnReadOnlyException.class)
   public void testMutationsInReadOnlyTransactions() {
     try (AsyncTransaction txn = dgraphAsyncClient.newReadOnlyTransaction()) {

--- a/src/test/java/io/dgraph/DgraphClientTest.java
+++ b/src/test/java/io/dgraph/DgraphClientTest.java
@@ -104,7 +104,7 @@ public class DgraphClientTest extends DgraphIntegrationTest {
   public void testNewTransactionFromContext() {
     TxnContext ctx = TxnContext.newBuilder().setStartTs(1234L).build();
     try (Transaction txn = dgraphClient.newTransaction(ctx)) {
-      Response response = txn.query("{ result(func: uid(0x0)) { } }");
+      Response response = txn.query("{ result(func: uid(0x1)) { } }");
       assertEquals(response.getTxn().getStartTs(), 1234L);
     }
   }
@@ -113,7 +113,7 @@ public class DgraphClientTest extends DgraphIntegrationTest {
   public void testNewReadOnlyTransactionFromContext() {
     TxnContext ctx = TxnContext.newBuilder().setStartTs(1234L).build();
     try (Transaction txn = dgraphClient.newReadOnlyTransaction(ctx)) {
-      Response response = txn.query("{ result(func: uid(0x0)) { } }");
+      Response response = txn.query("{ result(func: uid(0x1)) { } }");
       assertEquals(response.getTxn().getStartTs(), 1234L);
     }
   }

--- a/src/test/java/io/dgraph/DgraphClientTest.java
+++ b/src/test/java/io/dgraph/DgraphClientTest.java
@@ -24,6 +24,7 @@ import com.google.protobuf.ByteString;
 import io.dgraph.DgraphProto.Mutation;
 import io.dgraph.DgraphProto.Operation;
 import io.dgraph.DgraphProto.Response;
+import io.dgraph.DgraphProto.TxnContext;
 import java.util.Collections;
 import java.util.Map;
 import org.testng.annotations.BeforeMethod;
@@ -96,6 +97,24 @@ public class DgraphClientTest extends DgraphIntegrationTest {
       jsonData = parser.parse(response.getJson().toStringUtf8()).getAsJsonObject();
       assertEquals(jsonData.getAsJsonArray("find_bob").size(), 0);
       txn.commit();
+    }
+  }
+
+  @Test
+  public void testNewTransactionFromContext() {
+    TxnContext ctx = TxnContext.newBuilder().setStartTs(1234L).build();
+    try (Transaction txn = dgraphClient.newTransaction(ctx)) {
+      Response response = txn.query("{ result(func: uid(0x0)) { } }");
+      assertEquals(response.getTxn().getStartTs(), 1234L);
+    }
+  }
+
+  @Test
+  public void testNewReadOnlyTransactionFromContext() {
+    TxnContext ctx = TxnContext.newBuilder().setStartTs(1234L).build();
+    try (Transaction txn = dgraphClient.newReadOnlyTransaction(ctx)) {
+      Response response = txn.query("{ result(func: uid(0x0)) { } }");
+      assertEquals(response.getTxn().getStartTs(), 1234L);
     }
   }
 


### PR DESCRIPTION
This PR adds support for creating a new transaction from `DgraphClient` and `DgraphAsyncClient` using an existing `TxnContext`.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph4j/149)
<!-- Reviewable:end -->
