### PR TITLE
feat: Client now has a checkVersion method

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,18 @@ DgraphGrpc.DgraphStub stub = DgraphGrpc.newStub(channel);
 DgraphClient dgraphClient = new DgraphClient(stub);
 ```
 
+### Check Dgraph version
+
+Checking the version of Dgraph server the client is interacting with is as easy as:
+```java
+Version v = dgraphClient.checkVersion();
+System.out.println(v.getTag());
+```
+Checking the version, before doing anything else can be used as a test to find out if the client
+is able to communicate with the Dgraph server. This will also help reduce the latency of the first
+query/mutation which results from some dynamic library loading and linking that happens in JVM
+(see [this issue](https://github.com/dgraph-io/dgraph4j/issues/108) for more details).
+
 ### Login Using ACL
 
 ```java

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ and understand how to run and work with Dgraph.
 - [Using the Synchronous Client](#using-the-synchronous-client)
   * [Creating a Client](#creating-a-client)
   * [Creating a Secure Client Using TLS](#creating-a-secure-client-using-tls)
+  * [Check Dgraph Version](#check-dgraph-version)
   * [Login Using ACL](#login-using-acl)
   * [Altering the Database](#altering-the-database)
   * [Creating a Transaction](#creating-a-transaction)
@@ -190,7 +191,7 @@ DgraphClient dgraphClient = new DgraphClient(stub);
 
 ### Check Dgraph version
 
-Checking the version of Dgraph server the client is interacting with is as easy as:
+Checking the version of the Dgraph server this client is interacting with is as easy as:
 ```java
 Version v = dgraphClient.checkVersion();
 System.out.println(v.getTag());

--- a/src/main/java/io/dgraph/DgraphAsyncClient.java
+++ b/src/main/java/io/dgraph/DgraphAsyncClient.java
@@ -20,6 +20,7 @@ import static java.util.Arrays.asList;
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.dgraph.DgraphProto.Payload;
 import io.dgraph.DgraphProto.TxnContext;
+import io.dgraph.DgraphProto.Version;
 import io.grpc.Context;
 import io.grpc.Metadata;
 import io.grpc.Status;
@@ -240,6 +241,27 @@ public class DgraphAsyncClient {
           StreamObserverBridge<Payload> observerBridge = new StreamObserverBridge<>();
           DgraphGrpc.DgraphStub localStub = getStubWithJwt(stub);
           localStub.alter(op, observerBridge);
+          return observerBridge.getDelegate();
+        });
+  }
+
+  /**
+   * checkVersion can be used to find out the version of the Dgraph instance this client is
+   * interacting with.
+   *
+   * @return A CompletableFuture containing the Version object which represents the version of
+   * Dgraph instance.
+   * */
+  public CompletableFuture<Version> checkVersion() {
+    final DgraphGrpc.DgraphStub stub = anyClient();
+    final DgraphProto.Check checkRequest = DgraphProto.Check.newBuilder().build();
+
+    return runWithRetries(
+        "checkVersion",
+        () -> {
+          StreamObserverBridge<Version> observerBridge = new StreamObserverBridge<>();
+          DgraphGrpc.DgraphStub localStub = getStubWithJwt(stub);
+          localStub.checkVersion(checkRequest, observerBridge);
           return observerBridge.getDelegate();
         });
   }

--- a/src/main/java/io/dgraph/DgraphClient.java
+++ b/src/main/java/io/dgraph/DgraphClient.java
@@ -17,6 +17,7 @@ package io.dgraph;
 
 import io.dgraph.DgraphProto.Operation;
 import io.dgraph.DgraphProto.TxnContext;
+import io.dgraph.DgraphProto.Version;
 
 /**
  * Implementation of a DgraphClient using grpc.
@@ -123,6 +124,16 @@ public class DgraphClient {
         () -> {
           asyncClient.alter(op).join();
         });
+  }
+
+  /**
+   * checkVersion can be used to find out the version of the Dgraph instance this client is
+   * interacting with.
+   *
+   * @return A Version object which represents the version of Dgraph instance.
+   * */
+  public Version checkVersion() {
+    return asyncClient.checkVersion().join();
   }
 
   /**

--- a/src/test/java/io/dgraph/DgraphAsyncClientTest.java
+++ b/src/test/java/io/dgraph/DgraphAsyncClientTest.java
@@ -15,8 +15,7 @@
  */
 package io.dgraph;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -162,5 +161,12 @@ public class DgraphAsyncClientTest {
     assertTrue(jsonData.has("me"));
     String name = jsonData.getAsJsonArray("me").get(0).getAsJsonObject().get("name").getAsString();
     assertEquals(name, "Alice");
+  }
+
+  @Test
+  public void testCheckVersion() {
+    DgraphProto.Version v = dgraphAsyncClient.checkVersion().join();
+    assertTrue(v.getTag().length() > 0);
+    assertEquals(v.getTag().charAt(0), 'v');
   }
 }

--- a/src/test/java/io/dgraph/DgraphClientTest.java
+++ b/src/test/java/io/dgraph/DgraphClientTest.java
@@ -143,4 +143,11 @@ public class DgraphClientTest extends DgraphIntegrationTest {
       txn.mutate(mu);
     }
   }
+
+  @Test
+  public void testCheckVersion() {
+    DgraphProto.Version v = dgraphClient.checkVersion();
+    assertTrue(v.getTag().length() > 0);
+    assertEquals(v.getTag().charAt(0), 'v');
+  }
 }


### PR DESCRIPTION
Fixes #145.
Fixes DGRAPH-1888.
This PR adds a `checkVersion()` method to both `DgraphClient` and `DgraphAsyncClient`. This method can be used to find out the version of Dgraph instance the client is interacting with.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph4j/155)
<!-- Reviewable:end -->
