### PR TITLE
feat: Add support for RDF response (DGRAPH-2659)

### DIFF
--- a/src/main/java/io/dgraph/AsyncTransaction.java
+++ b/src/main/java/io/dgraph/AsyncTransaction.java
@@ -74,8 +74,8 @@ public class AsyncTransaction implements AutoCloseable {
    * same transaction, it's convenient to chain the method: <code>
    * client.NewTransaction().queryWithVars(...)</code>.
    *
-   * @param query query in GraphQL+-
-   * @param vars GraphQL variables used in query
+   * @param query query in DQL
+   * @param vars DQL variables used in query
    * @return a Response protocol buffer object.
    */
   public CompletableFuture<Response> queryWithVars(
@@ -96,11 +96,46 @@ public class AsyncTransaction implements AutoCloseable {
   /**
    * Calls {@code Transcation#queryWithVars} with an empty vars map.
    *
-   * @param query query in GraphQL+-
+   * @param query query in DQL
    * @return a Response protocol buffer object
    */
   public CompletableFuture<Response> query(final String query) {
     return queryWithVars(query, Collections.emptyMap());
+  }
+
+  /**
+   * Sends a query to one of the connected dgraph instances and returns RDF response. If no
+   * mutations need to be made in the same transaction, it's convenient to chain the method: <code>
+   * client.NewTransaction().queryRDFWithVars(...)</code>.
+   *
+   * @param query query in DQL
+   * @param vars DQL variables used in query
+   * @return a Response protocol buffer object.
+   */
+  public CompletableFuture<Response> queryRDFWithVars(
+      final String query, final Map<String, String> vars) {
+
+    final Request request =
+        Request.newBuilder()
+            .setQuery(query)
+            .putAllVars(vars)
+            .setStartTs(context.getStartTs())
+            .setReadOnly(readOnly)
+            .setBestEffort(bestEffort)
+            .setRespFormat(Request.RespFormat.RDF)
+            .build();
+
+    return this.doRequest(request);
+  }
+
+  /**
+   * Calls {@code Transcation#queryRDFWithVars} with an empty vars map.
+   *
+   * @param query query in DQL
+   * @return a Response protocol buffer object
+   */
+  public CompletableFuture<Response> queryRDF(final String query) {
+    return queryRDFWithVars(query, Collections.emptyMap());
   }
 
   /**

--- a/src/main/java/io/dgraph/Transaction.java
+++ b/src/main/java/io/dgraph/Transaction.java
@@ -41,8 +41,8 @@ public class Transaction implements AutoCloseable {
    * same transaction, it's convenient to chain the method: <code>
    * client.NewTransaction().queryWithVars(...) </code>.
    *
-   * @param query query in GraphQL+-
-   * @param vars GraphQL variables used in query
+   * @param query query in DQL
+   * @param vars DQL variables used in query
    * @return a Response protocol buffer object.
    */
   public Response queryWithVars(final String query, final Map<String, String> vars) {
@@ -53,11 +53,35 @@ public class Transaction implements AutoCloseable {
   /**
    * Calls {@code Transcation#queryWithVars} with an empty vars map.
    *
-   * @param query query in GraphQL+-
+   * @param query query in DQL
    * @return a Response protocol buffer object
    */
   public Response query(final String query) {
     return queryWithVars(query, Collections.emptyMap());
+  }
+
+  /**
+   * Sends a query to one of the connected dgraph instances and returns RDF response. If no
+   * mutations need to be made in the same transaction, it's convenient to chain the method: <code>
+   * client.NewTransaction().queryWithVars(...) </code>.
+   *
+   * @param query query in DQL
+   * @param vars DQL variables used in query
+   * @return a Response protocol buffer object.
+   */
+  public Response queryRDFWithVars(final String query, final Map<String, String> vars) {
+    return ExceptionUtil.withExceptionUnwrapped(
+        () -> asyncTransaction.queryRDFWithVars(query, vars).join());
+  }
+
+  /**
+   * Calls {@code Transcation#queryRDFWithVars} with an empty vars map.
+   *
+   * @param query query in DQL
+   * @return a Response protocol buffer object
+   */
+  public Response queryRDF(final String query) {
+    return queryRDFWithVars(query, Collections.emptyMap());
   }
 
   /**

--- a/src/main/proto/api.proto
+++ b/src/main/proto/api.proto
@@ -52,10 +52,19 @@ message Request {
 
 	repeated Mutation mutations = 12;
 	bool commit_now = 13;
+	enum RespFormat {
+		JSON = 0;
+		RDF = 1;
+	}
+	RespFormat resp_format = 14;
 }
 
 message Uids {
 	repeated string uids = 1;
+}
+
+message ListOfString {
+    repeated string value = 1;
 }
 
 message Response {
@@ -67,6 +76,8 @@ message Response {
 	// uids contains a mapping of blank_node => uid for the node. It only returns uids
 	// that were created as part of a mutation.
 	map<string, string> uids = 12;
+	bytes rdf = 13;
+	map<string, ListOfString> hdrs = 14;
 }
 
 message Mutation {

--- a/src/test/java/io/dgraph/DgraphAsyncClientTest.java
+++ b/src/test/java/io/dgraph/DgraphAsyncClientTest.java
@@ -177,14 +177,13 @@ public class DgraphAsyncClientTest {
             .setCommitNow(true)
             .setSetJson(ByteString.copyFromUtf8(jsonData.toString()))
             .build();
-    dgraphAsyncClient.newTransaction().mutate(mu).join();
     Response muRes = dgraphAsyncClient.newTransaction().mutate(mu).join();
 
     // Query
     String query = "query me($a: string) { me(func: eq(name, $a)) { name }}";
     Map<String, String> vars = Collections.singletonMap("$a", "Alice");
     Response response =
-        dgraphAsyncClient.newReadOnlyTransaction().queryWithVars(query, vars).join();
+        dgraphAsyncClient.newReadOnlyTransaction().queryRDFWithVars(query, vars).join();
 
     // Verify data as expected
     assertEquals(muRes.getUidsMap().values().size(), 1);

--- a/src/test/java/io/dgraph/DgraphAsyncClientTest.java
+++ b/src/test/java/io/dgraph/DgraphAsyncClientTest.java
@@ -189,7 +189,7 @@ public class DgraphAsyncClientTest {
     // Verify data as expected
     assertEquals(muRes.getUidsMap().values().size(), 1);
     String uid = (String) muRes.getUidsMap().values().toArray()[0];
-    assertEquals(response.getRdf().toStringUtf8(), "<"+uid+"> <name> \"Alice\" .\n");
+    assertEquals(response.getRdf().toStringUtf8(), "<" + uid + "> <name> \"Alice\" .\n");
   }
 
   @Test

--- a/src/test/java/io/dgraph/DgraphAsyncClientTest.java
+++ b/src/test/java/io/dgraph/DgraphAsyncClientTest.java
@@ -164,6 +164,35 @@ public class DgraphAsyncClientTest {
   }
 
   @Test
+  public void testQueryRDFInReadOnlyTransactions() {
+    Operation op = Operation.newBuilder().setSchema("name: string @index(exact) @upsert .").build();
+    dgraphAsyncClient.alter(op).join();
+
+    // Mutation
+    JsonObject jsonData = new JsonObject();
+    jsonData.addProperty("name", "Alice");
+
+    Mutation mu =
+        Mutation.newBuilder()
+            .setCommitNow(true)
+            .setSetJson(ByteString.copyFromUtf8(jsonData.toString()))
+            .build();
+    dgraphAsyncClient.newTransaction().mutate(mu).join();
+    Response muRes = dgraphAsyncClient.newTransaction().mutate(mu).join();
+
+    // Query
+    String query = "query me($a: string) { me(func: eq(name, $a)) { name }}";
+    Map<String, String> vars = Collections.singletonMap("$a", "Alice");
+    Response response =
+        dgraphAsyncClient.newReadOnlyTransaction().queryWithVars(query, vars).join();
+
+    // Verify data as expected
+    assertEquals(muRes.getUidsMap().values().size(), 1);
+    String uid = (String) muRes.getUidsMap().values().toArray()[0];
+    assertEquals(response.getRdf().toStringUtf8(), "<"+uid+"> <name> \"Alice\" .\n");
+  }
+
+  @Test
   public void testCheckVersion() {
     DgraphProto.Version v = dgraphAsyncClient.checkVersion().join();
     assertTrue(v.getTag().length() > 0);

--- a/src/test/java/io/dgraph/DgraphClientTest.java
+++ b/src/test/java/io/dgraph/DgraphClientTest.java
@@ -96,7 +96,7 @@ public class DgraphClientTest extends DgraphIntegrationTest {
     // Verify data as expected
     assertEquals(muRes.getUidsMap().values().size(), 1);
     String uid = (String) muRes.getUidsMap().values().toArray()[0];
-    assertEquals(response.getRdf().toStringUtf8(), "<"+uid+"> <name> \"Alice\" .\n");
+    assertEquals(response.getRdf().toStringUtf8(), "<" + uid + "> <name> \"Alice\" .\n");
   }
 
   @Test


### PR DESCRIPTION
This PR updates `api.proto` to reflect the latest gRPC API. In addition, it also adds client methods to query RDF in a transaction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph4j/160)
<!-- Reviewable:end -->
