### PR TITLE
feat: add client constructor with executor (DGRAPH-2746)

### DIFF
--- a/src/main/java/io/dgraph/DgraphClient.java
+++ b/src/main/java/io/dgraph/DgraphClient.java
@@ -23,6 +23,7 @@ import io.grpc.Metadata;
 import io.grpc.stub.MetadataUtils;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.concurrent.Executor;
 
 /**
  * Implementation of a DgraphClient using grpc.
@@ -75,6 +76,20 @@ public class DgraphClient {
    */
   public DgraphClient(DgraphGrpc.DgraphStub... stubs) {
     this.asyncClient = new DgraphAsyncClient(stubs);
+  }
+
+  /**
+   * Creates a new client for interacting with a Dgraph store.
+   *
+   * <p>A single client is thread safe.
+   *
+   * @param executor - the executor to use for various asynchronous tasks executed by the underlying
+   *     asynchronous client.
+   * @param stubs - an array of grpc stubs to be used by this client. The stubs to be used are
+   *     chosen at random per transaction.
+   */
+  public DgraphClient(Executor executor, DgraphGrpc.DgraphStub... stubs) {
+    this.asyncClient = new DgraphAsyncClient(executor, stubs);
   }
 
   /**


### PR DESCRIPTION
Fixes DGRAPH-2746
Fixes [Discuss Issue](https://discuss.dgraph.io/t/dgraph4j-support-for-custom-executor/11530)

This PR adds a constructor to `DgraphAsyncClient` which accepts a `java.util.concurrent.Executor` argument to be used to process various asynchronous tasks executed by the client. This is useful in scenarios where one wants to do resource management manually, and not use the default pool provided by `java.util.concurrent.ForkJoinPool.commonPool()`.

It also adds a similar constructor to the synchronous version of the client: `DgraphClient`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph4j/161)
<!-- Reviewable:end -->
