### PR TITLE
feat: add loginIntoNamespace API on clients (GRAPHQL-1058)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,9 +216,15 @@ query/mutation which results from some dynamic library loading and linking that 
 
 ### Login Using ACL
 
+If ACL is enabled then you can log-in to the default namespace (0) with following:
 ```java
 dgraphClient.login(USER_ID, USER_PASSWORD);
 ```
+For logging-in to some other namespace, use the `loginIntoNamespace` method on the client:
+```java
+dgraphClient.loginIntoNamespace(USER_ID, USER_PASSWORD, NAMESPACE);
+```
+Once logged-in, the `dgraphClient` object can be used to do any further operations.
 
 ### Altering the Database
 

--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ ClientInterceptor timeoutInterceptor = new ClientInterceptor(){
         return next.newCall(method, callOptions.withDeadlineAfter(500, TimeUnit.MILLISECONDS));
     }
 };
-stub.withInterceptors(timeoutInterceptor);
+stub = stub.withInterceptors(timeoutInterceptor);
 DgraphClient dgraphClient = new DgraphClient(stub);
 ```
 

--- a/src/main/java/io/dgraph/DgraphClient.java
+++ b/src/main/java/io/dgraph/DgraphClient.java
@@ -185,15 +185,29 @@ public class DgraphClient {
   }
 
   /**
-   * login sends a LoginRequest to the server that contains the userid and password. If the
-   * LoginRequest is processed successfully, the response returned by the server will contain an
-   * access JWT and a refresh JWT, which will be stored in the jwt field of this class, and used for
-   * authorizing all subsequent requests sent to the server.
+   * login sends a LoginRequest to the server using the given userid and password for the default
+   * namespace (0). If the LoginRequest is processed successfully, the response returned by the
+   * server will contain an access JWT and a refresh JWT, which will be stored in the jwt field of
+   * this class, and used for authorizing all subsequent requests sent to the server.
    *
    * @param userid the id of the user who is trying to login, e.g. Alice
    * @param password the password of the user
    */
   public void login(String userid, String password) {
     asyncClient.login(userid, password).join();
+  }
+
+  /**
+   * loginIntoNamespace sends a LoginRequest to the server using the given userid, password and
+   * namespace. If the LoginRequest is processed successfully, the response returned by the server
+   * will contain an access JWT and a refresh JWT, which will be stored in the jwt field of this
+   * class, and used for authorizing all subsequent requests sent to the server.
+   *
+   * @param userid the id of the user who is trying to login, e.g. Alice
+   * @param password the password of the user
+   * @param namespace the namespace in which to login
+   */
+  public void loginIntoNamespace(String userid, String password, long namespace) {
+    asyncClient.loginIntoNamespace(userid, password, namespace).join();
   }
 }

--- a/src/main/proto/api.proto
+++ b/src/main/proto/api.proto
@@ -150,13 +150,14 @@ message Metrics {
 }
 
 message NQuad {
+	reserved 5; // This was used for label.
 	string subject = 1;
 	string predicate = 2;
 	string object_id = 3;
 	Value object_value = 4;
-	string label = 5;
 	string lang = 6;
 	repeated Facet facets = 7;
+	uint64 namespace = 8;
 }
 
 message Value {
@@ -195,6 +196,7 @@ message LoginRequest {
 	string userid = 1;
 	string password = 2;
 	string refresh_token = 3;
+	uint64 namespace = 4;
 }
 
 message Jwt {


### PR DESCRIPTION
This PR does the following things:
* sync `api.proto` with `dgo`
* add `loginIntoNamespace` api on `DgraphClient` and `DgraphAsyncClient`
* fix a documentation issue in README.md and also add docs about this feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph4j/166)
<!-- Reviewable:end -->
