### PR TITLE
chore: Sync dgo + deprecate Slash endpoint method (GRAPHQL-1141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Calendar Versioning](https://calver.org/) starting 
 
 ## [20.03.2] - 2020-10-27
 ### Added
-* feat: Support for Slash GraphqQL endpoint ([#158])
+* feat: Support for Slash GraphQL endpoint ([#158])
 
 [#158]: https://github.com/dgraph-io/dgraph4j/pull/158
 

--- a/src/main/java/io/dgraph/AsyncTransaction.java
+++ b/src/main/java/io/dgraph/AsyncTransaction.java
@@ -194,7 +194,11 @@ public class AsyncTransaction implements AutoCloseable {
       mutated = true;
     }
 
-    Request requestStartTs = Request.newBuilder(request).setStartTs(context.getStartTs()).build();
+    Request requestStartTs =
+        Request.newBuilder(request)
+            .setStartTs(context.getStartTs())
+            .setHash(context.getHash())
+            .build();
 
     return client
         .runWithRetries(
@@ -293,6 +297,8 @@ public class AsyncTransaction implements AutoCloseable {
 
   private void mergeContext(final TxnContext src) {
     TxnContext.Builder builder = TxnContext.newBuilder(context);
+
+    builder.setHash(src.getHash());
 
     if (context.getStartTs() == 0) {
       builder.setStartTs(src.getStartTs());

--- a/src/main/java/io/dgraph/DgraphClient.java
+++ b/src/main/java/io/dgraph/DgraphClient.java
@@ -43,12 +43,14 @@ public class DgraphClient {
 
   /**
    * Creates a gRPC stub that can be used to construct clients to connect with Slash GraphQL.
-   *
    * @param slashEndpoint The url of the Slash GraphQL endpoint. Example:
    *     https://your-slash-instance.cloud.dgraph.io/graphql
    * @param apiKey The API key used to connect to your Slash GraphQL instance.
    * @return A new DgraphGrpc.DgraphStub object to be used with DgraphClient/DgraphAsyncClient.
+   * @deprecated This method will be removed in v21.07 release. For more details, see:
+   * https://discuss.dgraph.io/t/regarding-slash-cloud-dgraph-endpoints-in-the-clients/13492
    */
+  @Deprecated
   public static DgraphGrpc.DgraphStub clientStubFromSlashEndpoint(
       String slashEndpoint, String apiKey) throws MalformedURLException {
     String[] parts = new URL(slashEndpoint).getHost().split("[.]", 2);

--- a/src/main/java/io/dgraph/DgraphClient.java
+++ b/src/main/java/io/dgraph/DgraphClient.java
@@ -43,12 +43,13 @@ public class DgraphClient {
 
   /**
    * Creates a gRPC stub that can be used to construct clients to connect with Slash GraphQL.
+   *
    * @param slashEndpoint The url of the Slash GraphQL endpoint. Example:
    *     https://your-slash-instance.cloud.dgraph.io/graphql
    * @param apiKey The API key used to connect to your Slash GraphQL instance.
    * @return A new DgraphGrpc.DgraphStub object to be used with DgraphClient/DgraphAsyncClient.
    * @deprecated This method will be removed in v21.07 release. For more details, see:
-   * https://discuss.dgraph.io/t/regarding-slash-cloud-dgraph-endpoints-in-the-clients/13492
+   *     https://discuss.dgraph.io/t/regarding-slash-cloud-dgraph-endpoints-in-the-clients/13492
    */
   @Deprecated
   public static DgraphGrpc.DgraphStub clientStubFromSlashEndpoint(

--- a/src/main/proto/api.proto
+++ b/src/main/proto/api.proto
@@ -57,6 +57,7 @@ message Request {
 		RDF = 1;
 	}
 	RespFormat resp_format = 14;
+	string hash = 15;
 }
 
 message Uids {
@@ -128,6 +129,7 @@ message TxnContext {
 	bool aborted = 3;
 	repeated string keys = 4;  // List of keys to be used for conflict detection.
 	repeated string preds = 5; // List of predicates involved in this transaction.
+	string hash = 6;
 }
 
 message Check {}

--- a/src/test/java/io/dgraph/AclTest.java
+++ b/src/test/java/io/dgraph/AclTest.java
@@ -16,7 +16,7 @@ import org.testng.annotations.Test;
 public class AclTest extends DgraphIntegrationTest {
   private static final String USER_ID = "alice";
   private static final String USER_PASSWORD = "simplepassword";
-  private static final String GROOT_PASSWORD = "password";
+  private static final String GUARDIAN_CREDS = "user=groot;password=password;namespace=0";
   private static final String PREDICATE_TO_READ = "predicate_to_read";
   private static final String PREDICATE_TO_WRITE = "predicate_to_write";
   private static final String PREDICATE_TO_ALTER = "predicate_to_alter";
@@ -101,8 +101,8 @@ public class AclTest extends DgraphIntegrationTest {
         DGRAPH_ENDPOINT,
         "-g",
         group,
-        "-x",
-        GROOT_PASSWORD);
+        "--guardian-creds",
+        GUARDIAN_CREDS);
 
     if (addUserToGroup) {
       checkCmd(
@@ -116,8 +116,8 @@ public class AclTest extends DgraphIntegrationTest {
           USER_ID,
           "--group_list",
           group,
-          "-x",
-          GROOT_PASSWORD);
+          "--guardian-creds",
+          GUARDIAN_CREDS);
     }
 
     // add READ permission on the predicate_to_read to the group
@@ -134,8 +134,8 @@ public class AclTest extends DgraphIntegrationTest {
         PREDICATE_TO_READ,
         "-m",
         "4",
-        "-x",
-        GROOT_PASSWORD);
+        "--guardian-creds",
+        GUARDIAN_CREDS);
 
     // also add READ permission on the attribute queryAttr, which is used inside the query block
     checkCmd(
@@ -151,8 +151,8 @@ public class AclTest extends DgraphIntegrationTest {
         QUERY_ATTR,
         "-m",
         "4",
-        "-x",
-        GROOT_PASSWORD);
+        "--guardian-creds",
+        GUARDIAN_CREDS);
 
     checkCmd(
         "unable to add WRITE permission on " + PREDICATE_TO_WRITE + " to the group " + group,
@@ -167,8 +167,8 @@ public class AclTest extends DgraphIntegrationTest {
         PREDICATE_TO_WRITE,
         "-m",
         "2",
-        "-x",
-        GROOT_PASSWORD);
+        "--guardian-creds",
+        GUARDIAN_CREDS);
 
     checkCmd(
         "unable to add ALTER permission on " + PREDICATE_TO_ALTER + " to the group " + group,
@@ -183,8 +183,8 @@ public class AclTest extends DgraphIntegrationTest {
         PREDICATE_TO_ALTER,
         "-m",
         "1",
-        "-x",
-        GROOT_PASSWORD);
+        "--guardian-creds",
+        GUARDIAN_CREDS);
   }
 
   private void removeUserFromAllGroups() throws IOException, InterruptedException {
@@ -199,8 +199,8 @@ public class AclTest extends DgraphIntegrationTest {
         USER_ID,
         "--group_list",
         "",
-        "-x",
-        GROOT_PASSWORD);
+        "--guardian-creds",
+        GUARDIAN_CREDS);
   }
 
   private void queryPredicateWithUserAccount(boolean shouldFail) {
@@ -280,7 +280,15 @@ public class AclTest extends DgraphIntegrationTest {
   private void resetUser() throws Exception {
     Process deleteUserCmd =
         new ProcessBuilder(
-                "dgraph", "acl", "del", "-a", DGRAPH_ENDPOINT, "-u", USER_ID, "-x", GROOT_PASSWORD)
+                "dgraph",
+                "acl",
+                "del",
+                "-a",
+                DGRAPH_ENDPOINT,
+                "-u",
+                USER_ID,
+                "--guardian-creds",
+                GUARDIAN_CREDS)
             .start();
     deleteUserCmd.waitFor();
 
@@ -295,8 +303,8 @@ public class AclTest extends DgraphIntegrationTest {
                 USER_ID,
                 "-p",
                 USER_PASSWORD,
-                "-x",
-                GROOT_PASSWORD)
+                "--guardian-creds",
+                GUARDIAN_CREDS)
             .redirectErrorStream(true)
             .start();
     createUserCmd.waitFor();


### PR DESCRIPTION
This PR does following things:
* Make transaction context more robust (Ref: https://github.com/dgraph-io/dgo/pull/146)
* Deprecate `DgraphClient.clientStubfromSlashEndpoint` (Ref: https://discuss.dgraph.io/t/regarding-slash-cloud-dgraph-endpoints-in-the-clients/13492)
* Fix a test to work with dgraph v21.03
* Fix typo in CHANGELOG.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph4j/167)
<!-- Reviewable:end -->
