### PR TITLE
chore: release v21.03.0 (GRAPHQL-1144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Calendar Versioning](https://calver.org/) starting 
 
 ## [Unreleased]
 
+## [21.03.0] - 2021-04-08
+### Added
+* feat: add loginIntoNamespace API on clients (GRAPHQL-1058) ([#166])
+### Deprecated
+* chore: Sync dgo + deprecate Slash endpoint method (GRAPHQL-1141) ([#167])
+### Fixed
+* fix(test): Don't use dgraph binary in tests (GRAPHQL-1144) ([#168])
+
+[#166]: https://github.com/dgraph-io/dgraph4j/pull/166
+[#167]: https://github.com/dgraph-io/dgraph4j/pull/167
+[#168]: https://github.com/dgraph-io/dgraph4j/pull/168
+
 ## [20.11.0] - 2020-12-23
 ### Added
 * feat: Add support for RDF response (DGRAPH-2659) ([#160])
@@ -139,7 +151,8 @@ and this project adheres to [Calendar Versioning](https://calver.org/) starting 
 ## [1.0.0] - 2017-12-18
 * Fully compatible with Dgraph v1.0
 
-[Unreleased]: https://github.com/dgraph-io/dgraph4j/compare/v20.11.0...HEAD
+[Unreleased]: https://github.com/dgraph-io/dgraph4j/compare/v20.03.0...HEAD
+[21.03.0]: https://github.com/dgraph-io/dgraph4j/compare/v20.11.0...v20.03.0
 [20.11.0]: https://github.com/dgraph-io/dgraph4j/compare/v20.03.3...v20.11.0
 [20.03.3]: https://github.com/dgraph-io/dgraph4j/compare/v20.03.2...v20.03.3
 [20.03.2]: https://github.com/dgraph-io/dgraph4j/compare/v20.03.1...v20.03.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,8 +151,8 @@ and this project adheres to [Calendar Versioning](https://calver.org/) starting 
 ## [1.0.0] - 2017-12-18
 * Fully compatible with Dgraph v1.0
 
-[Unreleased]: https://github.com/dgraph-io/dgraph4j/compare/v20.03.0...HEAD
-[21.03.0]: https://github.com/dgraph-io/dgraph4j/compare/v20.11.0...v20.03.0
+[Unreleased]: https://github.com/dgraph-io/dgraph4j/compare/v21.03.0...HEAD
+[21.03.0]: https://github.com/dgraph-io/dgraph4j/compare/v20.11.0...v21.03.0
 [20.11.0]: https://github.com/dgraph-io/dgraph4j/compare/v20.03.3...v20.11.0
 [20.03.3]: https://github.com/dgraph-io/dgraph4j/compare/v20.03.2...v20.03.3
 [20.03.2]: https://github.com/dgraph-io/dgraph4j/compare/v20.03.1...v20.03.2

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -28,6 +28,7 @@ ossrhPassword=<…password…>
 * Bump version by modifying the `version` variable in `build.gradle` file.
 * Update download version in README for both Maven and Gradle.
 * Update `dgraph4j version` in `grpc-netty` table in README.
+* Update CHANGELOG.
 * Raise a PR for the above changes. Put the changelog in PR description and merge it.
 * Run `./gradlew uploadArchives`.
 * Release the deployment by following the steps on the page _Releasing the Deployment_ (link in references below).

--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ use a different version of this client.
 |:--------------:|:-----------------:|:------------:|
 |     1.0.X      |       1.X.X       |     1.9.X    |
 |  1.1.0 - 2.X.X |       2.X.X       |     1.9.X    |
-|   >= 20.XX.X   |      20.XX.X      |     1.9.X    |
+|20.03.X-20.07.X |      20.03.X      |     1.9.X    |
+|     20.11.X    |      20.11.X      |     1.9.X    |
+|   >= 21.XX.X   |      21.XX.X      |     1.9.X    |
 
 #### Note regarding Java 1.8.x support:
 * If you aren't using gRPC with TLS, then the above version table will work for you with Java

--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ grab via Maven:
 <dependency>
   <groupId>io.dgraph</groupId>
   <artifactId>dgraph4j</artifactId>
-  <version>20.11.0</version>
+  <version>21.03.0</version>
 </dependency>
 ```
 or Gradle:
 ```groovy
-compile 'io.dgraph:dgraph4j:20.11.0'
+compile 'io.dgraph:dgraph4j:21.03.0'
 ```
 
 ## Supported Versions

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ apply plugin: 'signing'
 
 group = 'io.dgraph'
 archivesBaseName = 'dgraph4j'
-version = '20.11.0'
+version = '21.03.0'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 


### PR DESCRIPTION
### Added
* feat: add loginIntoNamespace API on clients (GRAPHQL-1058) (#166)
### Deprecated
* chore: Sync dgo + deprecate Slash endpoint method (GRAPHQL-1141) (#167)
### Fixed
* fix(test): Don't use dgraph binary in tests (GRAPHQL-1144) (#168)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph4j/169)
<!-- Reviewable:end -->
