### PR TITLE
update Gradle Action

### DIFF
--- a/.github/workflows/ci-dgraph4j-tests.yml
+++ b/.github/workflows/ci-dgraph4j-tests.yml
@@ -36,7 +36,7 @@ jobs:
           distribution: microsoft
           java-version-file: dgraph4j/.java-version
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
       - name: Get Go Version
         run: |
           #!/bin/bash


### PR DESCRIPTION
replacing deprecated Action per https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle