### PR TITLE
Upgrade gradlew to gradle 7.6.4

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Current `build.gradle` does not work with Gradle 6:

```
FAILURE: Build failed with an exception.

* Where:
Build file '.../dgraph4j/build.gradle' line: 46

* What went wrong:
A problem occurred evaluating root project 'dgraph4j'.
> Could not find method base() for arguments [build_v9fysx0wd2y7qeqfcjc5a1h4$_run_closure1@4c74018b] on root project 'dgraph4j' of type org.gradle.api.Project.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 467ms
```

So `gradlew` should reference a version that works with it.

Could also upgrade to Gradle 8.