### PR TITLE
Provide shaded jar with dgraph4j's dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 buildscript {
     repositories {
         maven {
@@ -32,6 +34,7 @@ plugins {
     id 'com.github.sherter.google-java-format' version '0.9'
     id 'base'
     id 'maven-publish'
+    id 'com.gradleup.shadow' version '8.3.2'
 }
 // Apply the java plugin to add support for Java
 apply plugin: 'java'
@@ -171,6 +174,14 @@ task fatJar(type: Jar) {
     with jar
 }
 
+tasks.named('shadowJar', ShadowJar) {
+    enableRelocation true
+    relocationPrefix "io.dgraph.dgraph4j.shaded"
+    relocate 'google', 'io.dgraph.dgraph4j.shaded.google'
+    archiveClassifier.set("shaded")
+    mergeServiceFiles()
+}
+
 task buildJar(type: Jar)
 
 task javadocJar(type: Jar) {
@@ -201,6 +212,7 @@ task integrationTest(type: Test) {
 
 artifacts {
     archives jar
+    archives shadowJar
     archives sourceJar
     archives javadocJar
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Using the Dgraph4j client in an application that is bound to its own Netty dependency version like Apache Spark creates conflicts that can only be resolved by shading Dgraph4j's dependencies.

Please release the shaded jar together with your other artifacts.