### PR TITLE
fix: make DgraphAsyncClient non-blocking to avoid ForkJoinPool.commonPool starvation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/),
   the result of the work the transaction wrapped. Code that catches a close-time failure from an
   async transaction no longer sees one. `Transaction.close()` still throws; both javadocs record the
   difference. ([#294])
+- `DgraphAsyncClient.withRetry` completes exceptionally with a bare `DgraphException` on every path,
+  so `whenComplete`, `handle`, and `exceptionally` callbacks receive the `DgraphException` itself.
+  Retry exhaustion previously handed those callbacks a `CompletionException` wrapping it, while a
+  first-attempt failure handed them the exception directly. `join()` and `get()` are unaffected:
+  both wrapped before and still wrap. `DgraphClient.withRetry` runs a separate synchronous retry
+  loop and is unchanged. ([#294])
 
 **Fixed**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+**Fixed**
+
+- fix: `DgraphAsyncClient` no longer blocks a `ForkJoinPool.commonPool()` thread for the full
+  duration of each gRPC call, which could starve the JVM-wide common pool under load.
+  `CompletableFutures.runWithRetries` now composes on the gRPC future instead of calling a blocking
+  `.get()`, and `jwt` writes are guarded by the write lock. ([#294])
+
 ## [25.0.0] - 2026-04-01
 
 **Added**
@@ -104,6 +111,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/),
 
 - chore: added a test for best effort queries ([#182])
 
+[#294]: https://github.com/dgraph-io/dgraph4j/pull/294
 [#287]: https://github.com/dgraph-io/dgraph4j/pull/287
 [#220]: https://github.com/hypermodeinc/dgraph4j/pull/220
 [#215]: https://github.com/hypermodeinc/dgraph4j/pull/215

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,34 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+**Changed**
+
+- `AsyncTransaction.close()` logs a failed abort instead of throwing it, so closing no longer masks
+  the result of the work the transaction wrapped. Code that catches a close-time failure from an
+  async transaction no longer sees one. `Transaction.close()` still throws; both javadocs record the
+  difference. ([#294])
+
 **Fixed**
 
 - fix: `DgraphAsyncClient` no longer blocks a `ForkJoinPool.commonPool()` thread for the full
   duration of each gRPC call, which could starve the JVM-wide common pool under load.
   `CompletableFutures.runWithRetries` now composes on the gRPC future instead of calling a blocking
   `.get()`, and `jwt` writes are guarded by the write lock. ([#294])
-- fix: futures returned by `DgraphAsyncClient` complete on the executor given to the constructor on
-  every path. The JWT-refresh retry previously completed on a gRPC channel thread, and `withRetry`'s
-  backoff ran on the common pool regardless of the configured executor. ([#294])
-- fix: `AsyncTransaction.close()` logs a failed abort instead of throwing it, so closing no longer
-  masks the result of the work the transaction wrapped. ([#294])
+- fix: futures returned by `DgraphAsyncClient` complete on the executor given to the constructor,
+  including the JWT-refresh retry and `withRetry`'s backoff, which previously completed on a gRPC
+  channel thread and on the common pool respectively. The one exception is a rejection by that
+  executor, which completes the future on whichever thread observed the rejection. ([#294])
+- fix: a `RejectedExecutionException` from the callback executor no longer leaves the returned
+  future permanently incomplete. `withRetry` now relays the rejection instead of hanging, and every
+  rejection surfaces as a `DgraphException` like any other failure. ([#294])
+
+**Deprecated**
+
+- `DgraphAsyncClient(DgraphGrpc.DgraphStub...)` is deprecated in favor of
+  `DgraphAsyncClient(Executor, DgraphGrpc.DgraphStub...)`. It still defaults to
+  `ForkJoinPool.commonPool()`, which is unsuitable for I/O continuations: it is a JVM-wide singleton
+  sized `availableProcessors() - 1`, cannot be tuned per library, and runs unnamed daemon threads
+  that hide contention in a thread dump. Compiling against it warns; nothing breaks. ([#294])
 
 ## [25.0.0] - 2026-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/),
   duration of each gRPC call, which could starve the JVM-wide common pool under load.
   `CompletableFutures.runWithRetries` now composes on the gRPC future instead of calling a blocking
   `.get()`, and `jwt` writes are guarded by the write lock. ([#294])
+- fix: futures returned by `DgraphAsyncClient` complete on the executor given to the constructor on
+  every path. The JWT-refresh retry previously completed on a gRPC channel thread, and
+  `withRetry`'s backoff ran on the common pool regardless of the configured executor. ([#294])
+- fix: `AsyncTransaction.close()` logs a failed abort instead of throwing it, so closing no longer
+  masks the result of the work the transaction wrapped. ([#294])
 
 ## [25.0.0] - 2026-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/),
   `CompletableFutures.runWithRetries` now composes on the gRPC future instead of calling a blocking
   `.get()`, and `jwt` writes are guarded by the write lock. ([#294])
 - fix: futures returned by `DgraphAsyncClient` complete on the executor given to the constructor on
-  every path. The JWT-refresh retry previously completed on a gRPC channel thread, and
-  `withRetry`'s backoff ran on the common pool regardless of the configured executor. ([#294])
+  every path. The JWT-refresh retry previously completed on a gRPC channel thread, and `withRetry`'s
+  backoff ran on the common pool regardless of the configured executor. ([#294])
 - fix: `AsyncTransaction.close()` logs a failed abort instead of throwing it, so closing no longer
   masks the result of the work the transaction wrapped. ([#294])
 

--- a/src/main/java/io/dgraph/AsyncTransaction.java
+++ b/src/main/java/io/dgraph/AsyncTransaction.java
@@ -400,6 +400,9 @@ public class AsyncTransaction implements AutoCloseable {
    * has uncommitted mutations, since {@link #discard()} short-circuits otherwise. A failed abort is
    * logged rather than thrown: the server cleans up abandoned transactions on its own, and throwing
    * here would mask the outcome of the work this transaction wrapped.
+   *
+   * <p>This diverges from {@link Transaction#close()}, which throws. That one is user-invoked
+   * through try-with-resources, whereas this one also runs from internal cleanup paths.
    */
   @Override
   public void close() {

--- a/src/main/java/io/dgraph/AsyncTransaction.java
+++ b/src/main/java/io/dgraph/AsyncTransaction.java
@@ -12,8 +12,12 @@ import io.dgraph.DgraphProto.Response;
 import io.dgraph.DgraphProto.TxnContext;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This is the implementation of asynchronous Dgraph transaction. The asynchrony is backed-up by
@@ -24,6 +28,7 @@ import java.util.concurrent.TimeUnit;
  * @author Michail Klimenkov
  */
 public class AsyncTransaction implements AutoCloseable {
+  private static final Logger LOG = LoggerFactory.getLogger(AsyncTransaction.class);
 
   // these can potentially be set from different threads executing the Stub callback
   private volatile TxnContext context;
@@ -390,8 +395,18 @@ public class AsyncTransaction implements AutoCloseable {
     this.context = builder.build();
   }
 
+  /**
+   * Discards the transaction, blocking until the abort completes. Blocks only when the transaction
+   * has uncommitted mutations, since {@link #discard()} short-circuits otherwise. A failed abort is
+   * logged rather than thrown: the server cleans up abandoned transactions on its own, and throwing
+   * here would mask the outcome of the work this transaction wrapped.
+   */
   @Override
   public void close() {
-    discard().join();
+    try {
+      discard().join();
+    } catch (CompletionException | CancellationException e) {
+      LOG.warn("discarding the transaction during close failed", e);
+    }
   }
 }

--- a/src/main/java/io/dgraph/CompletableFutures.java
+++ b/src/main/java/io/dgraph/CompletableFutures.java
@@ -118,13 +118,16 @@ final class CompletableFutures {
    * @param op the operation to execute within a fresh transaction on each attempt
    * @param attempt the current attempt number (0-based)
    * @param txnFactory creates a new read-write or read-only transaction per the policy
+   * @param executor the callback executor; the backoff delay and the returned future's completion
+   *     run on it, and no thread is held for the duration of a delay
    * @return a CompletableFuture that completes with the result or fails after exhausting retries
    */
   static <T> CompletableFuture<T> attemptAsync(
       RetryPolicy policy,
       AsyncTransactionOp<T> op,
       int attempt,
-      Supplier<AsyncTransaction> txnFactory) {
+      Supplier<AsyncTransaction> txnFactory,
+      Executor executor) {
 
     AsyncTransaction txn = txnFactory.get();
     if (policy.isBestEffort()) {
@@ -134,7 +137,7 @@ final class CompletableFutures {
     CompletableFuture<T> result = new CompletableFuture<>();
 
     op.execute(txn)
-        .whenComplete(
+        .whenCompleteAsync(
             (value, throwable) -> {
               try {
                 txn.discard();
@@ -153,12 +156,12 @@ final class CompletableFutures {
                 return;
               }
 
-              // Schedule retry after backoff delay
               long delayMs = policy.calculateDelay(attempt);
               Executor delayed =
-                  CompletableFuture.delayedExecutor(delayMs, TimeUnit.MILLISECONDS);
-              CompletableFuture.supplyAsync(() -> null, delayed)
-                  .thenCompose(ignored -> attemptAsync(policy, op, attempt + 1, txnFactory))
+                  CompletableFuture.delayedExecutor(delayMs, TimeUnit.MILLISECONDS, executor);
+              CompletableFuture.runAsync(() -> {}, delayed)
+                  .thenCompose(
+                      ignored -> attemptAsync(policy, op, attempt + 1, txnFactory, executor))
                   .whenComplete(
                       (retryValue, retryThrowable) -> {
                         if (retryThrowable != null) {
@@ -167,7 +170,8 @@ final class CompletableFutures {
                           result.complete(retryValue);
                         }
                       });
-            });
+            },
+            executor);
 
     return result;
   }

--- a/src/main/java/io/dgraph/CompletableFutures.java
+++ b/src/main/java/io/dgraph/CompletableFutures.java
@@ -48,7 +48,19 @@ final class CompletableFutures {
             (value, error) ->
                 classify(operation, value, error, ctxCallable, retryLogin, executor),
             executor)
-        .thenCompose(Function.identity());
+        .thenCompose(Function.identity())
+        .handle(CompletableFutures::translateTerminal);
+  }
+
+  /**
+   * Upholds the contract that every failure is a {@code CompletionException} wrapping a {@link
+   * DgraphException}. Runs synchronously so it still fires when {@code executor} rejects a stage.
+   */
+  private static <T> T translateTerminal(T value, Throwable error) {
+    if (error == null) {
+      return value;
+    }
+    throw new CompletionException(Exceptions.translate(unwrap(error)));
   }
 
   /** Runs the callable, turning a synchronous throw or a null result into a failed future. */
@@ -136,8 +148,10 @@ final class CompletableFutures {
 
     CompletableFuture<T> result = new CompletableFuture<>();
 
+    // handleAsync rather than whenCompleteAsync: the callback consumes the attempt's outcome, so
+    // the stage below carries only a rejection or a bug in the callback, never a retryable failure.
     op.execute(txn)
-        .whenCompleteAsync(
+        .handleAsync(
             (value, throwable) -> {
               try {
                 txn.discard();
@@ -147,31 +161,42 @@ final class CompletableFutures {
 
               if (throwable == null) {
                 result.complete(value);
-                return;
+                return null;
               }
 
               DgraphException ex = Exceptions.translate(throwable);
               if (!ex.isRetryable() || attempt >= policy.getMaxRetries()) {
                 result.completeExceptionally(ex);
-                return;
+                return null;
               }
 
               long delayMs = policy.calculateDelay(attempt);
-              Executor delayed =
-                  CompletableFuture.delayedExecutor(delayMs, TimeUnit.MILLISECONDS, executor);
+              // The timer takes no executor on purpose: delayedExecutor submits from the internal
+              // Delayer thread, which swallows a rejection and leaves this future incomplete.
+              Executor delayed = CompletableFuture.delayedExecutor(delayMs, TimeUnit.MILLISECONDS);
               CompletableFuture.runAsync(() -> {}, delayed)
-                  .thenCompose(
-                      ignored -> attemptAsync(policy, op, attempt + 1, txnFactory, executor))
+                  .thenComposeAsync(
+                      ignored -> attemptAsync(policy, op, attempt + 1, txnFactory, executor),
+                      executor)
                   .whenComplete(
                       (retryValue, retryThrowable) -> {
                         if (retryThrowable != null) {
-                          result.completeExceptionally(retryThrowable);
+                          result.completeExceptionally(Exceptions.translate(retryThrowable));
                         } else {
                           result.complete(retryValue);
                         }
                       });
+              return null;
             },
-            executor);
+            executor)
+        // A rejection by executor completes this stage exceptionally but leaves result untouched,
+        // so relay it or the caller waits forever.
+        .whenComplete(
+            (ignored, t) -> {
+              if (t != null) {
+                result.completeExceptionally(Exceptions.translate(t));
+              }
+            });
 
     return result;
   }

--- a/src/main/java/io/dgraph/CompletableFutures.java
+++ b/src/main/java/io/dgraph/CompletableFutures.java
@@ -7,6 +7,7 @@ package io.dgraph;
 
 import io.grpc.Context;
 import java.util.concurrent.*;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,40 +41,79 @@ final class CompletableFutures {
       Executor executor) {
     final Callable<CompletableFuture<T>> ctxCallable = Context.current().wrap(callable);
 
-    return CompletableFuture.supplyAsync(
-        () -> {
-          try {
-            return ctxCallable.call().get();
-          } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            LOG.error("The " + operation + " got interrupted:", e);
-            throw new DgraphException("The " + operation + " got interrupted", e);
-          } catch (ExecutionException e) {
-            if (Exceptions.isJwtExpired(e.getCause())) {
-              try {
-                retryLogin.get().get();
-                return ctxCallable.call().get();
-              } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
-                LOG.error("The retried " + operation + " got interrupted:", ie);
-                throw new DgraphException(
-                    "The retried " + operation + " got interrupted", ie);
-              } catch (ExecutionException ie) {
-                LOG.error(
-                    "The retried " + operation + " encounters an execution exception:", ie);
-                throw new CompletionException(Exceptions.translate(ie.getCause()));
-              } catch (Exception ie) {
-                LOG.error(
-                    "The retried " + operation + " encounters a completion exception:", ie);
-                throw new CompletionException(Exceptions.translate(ie));
-              }
-            }
-            throw new CompletionException(Exceptions.translate(e.getCause()));
-          } catch (Exception e) {
-            throw new CompletionException(Exceptions.translate(e));
-          }
-        },
-        executor);
+    // Fire the RPC (non-blocking) and compose on the resulting future. No thread is
+    // parked waiting for the round trip; the executor only runs the callback stages.
+    return invoke(ctxCallable)
+        .handleAsync(
+            (value, error) ->
+                classify(operation, value, error, ctxCallable, retryLogin, executor),
+            executor)
+        .thenCompose(Function.identity());
+  }
+
+  /**
+   * Invokes the callable, converting a thrown exception or a null result into an
+   * already-failed future so the caller never sees a synchronous throw.
+   */
+  private static <T> CompletableFuture<T> invoke(Callable<CompletableFuture<T>> callable) {
+    try {
+      CompletableFuture<T> future = callable.call();
+      if (future != null) {
+        return future;
+      }
+      CompletableFuture<T> failed = new CompletableFuture<>();
+      failed.completeExceptionally(new DgraphException("operation returned a null future"));
+      return failed;
+    } catch (Exception e) {
+      CompletableFuture<T> failed = new CompletableFuture<>();
+      failed.completeExceptionally(e);
+      return failed;
+    }
+  }
+
+  /** Strips one CompletionException wrapper so error classification sees the real cause. */
+  private static Throwable unwrap(Throwable t) {
+    if (t instanceof CompletionException && t.getCause() != null) {
+      return t.getCause();
+    }
+    return t;
+  }
+
+  /**
+   * Classifies the outcome of the first attempt: success passes through; a JWT-expiry
+   * failure triggers a single login refresh and retry; any other failure is translated.
+   * Always yields a future that completes with {@code CompletionException(DgraphException)}
+   * on failure.
+   */
+  private static <T> CompletableFuture<T> classify(
+      String operation,
+      T value,
+      Throwable error,
+      Callable<CompletableFuture<T>> ctxCallable,
+      Supplier<CompletableFuture<Void>> retryLogin,
+      Executor executor) {
+    if (error == null) {
+      return CompletableFuture.completedFuture(value);
+    }
+
+    Throwable cause = unwrap(error);
+    if (Exceptions.isJwtExpired(cause)) {
+      return retryLogin
+          .get()
+          .thenComposeAsync(ignored -> invoke(ctxCallable), executor)
+          .handle(
+              (retryValue, retryError) -> {
+                if (retryError != null) {
+                  LOG.error("The retried {} failed", operation, unwrap(retryError));
+                  throw new CompletionException(Exceptions.translate(unwrap(retryError)));
+                }
+                return retryValue;
+              });
+    }
+
+    CompletableFuture<T> failed = new CompletableFuture<>();
+    failed.completeExceptionally(new CompletionException(Exceptions.translate(cause)));
+    return failed;
   }
 
   /**

--- a/src/main/java/io/dgraph/CompletableFutures.java
+++ b/src/main/java/io/dgraph/CompletableFutures.java
@@ -41,9 +41,9 @@ final class CompletableFutures {
       Executor executor) {
     final Callable<CompletableFuture<T>> ctxCallable = Context.current().wrap(callable);
 
-    // Fire the RPC (non-blocking) and compose on the resulting future. No thread is
-    // parked waiting for the round trip; the executor only runs the callback stages.
-    return invoke(ctxCallable)
+    // Composing on the gRPC future rather than blocking on it keeps every stage off the
+    // critical path: no thread is parked for the round trip.
+    return invoke(operation, ctxCallable)
         .handleAsync(
             (value, error) ->
                 classify(operation, value, error, ctxCallable, retryLogin, executor),
@@ -51,23 +51,18 @@ final class CompletableFutures {
         .thenCompose(Function.identity());
   }
 
-  /**
-   * Invokes the callable, converting a thrown exception or a null result into an
-   * already-failed future so the caller never sees a synchronous throw.
-   */
-  private static <T> CompletableFuture<T> invoke(Callable<CompletableFuture<T>> callable) {
+  /** Runs the callable, turning a synchronous throw or a null result into a failed future. */
+  private static <T> CompletableFuture<T> invoke(
+      String operation, Callable<CompletableFuture<T>> callable) {
     try {
       CompletableFuture<T> future = callable.call();
       if (future != null) {
         return future;
       }
-      CompletableFuture<T> failed = new CompletableFuture<>();
-      failed.completeExceptionally(new DgraphException("operation returned a null future"));
-      return failed;
+      return CompletableFuture.failedFuture(
+          new DgraphException("The " + operation + " returned a null future"));
     } catch (Exception e) {
-      CompletableFuture<T> failed = new CompletableFuture<>();
-      failed.completeExceptionally(e);
-      return failed;
+      return CompletableFuture.failedFuture(e);
     }
   }
 
@@ -80,10 +75,9 @@ final class CompletableFutures {
   }
 
   /**
-   * Classifies the outcome of the first attempt: success passes through; a JWT-expiry
-   * failure triggers a single login refresh and retry; any other failure is translated.
-   * Always yields a future that completes with {@code CompletionException(DgraphException)}
-   * on failure.
+   * Passes a success through, retries once after a JWT refresh on an expired-token failure, and
+   * translates every other failure to {@code CompletionException(DgraphException)}. All paths
+   * complete on {@code executor}.
    */
   private static <T> CompletableFuture<T> classify(
       String operation,
@@ -100,20 +94,19 @@ final class CompletableFutures {
     if (Exceptions.isJwtExpired(cause)) {
       return retryLogin
           .get()
-          .thenComposeAsync(ignored -> invoke(ctxCallable), executor)
-          .handle(
+          .thenComposeAsync(ignored -> invoke(operation, ctxCallable), executor)
+          .handleAsync(
               (retryValue, retryError) -> {
                 if (retryError != null) {
                   LOG.error("The retried {} failed", operation, unwrap(retryError));
                   throw new CompletionException(Exceptions.translate(unwrap(retryError)));
                 }
                 return retryValue;
-              });
+              },
+              executor);
     }
 
-    CompletableFuture<T> failed = new CompletableFuture<>();
-    failed.completeExceptionally(new CompletionException(Exceptions.translate(cause)));
-    return failed;
+    return CompletableFuture.failedFuture(new CompletionException(Exceptions.translate(cause)));
   }
 
   /**

--- a/src/main/java/io/dgraph/DgraphAsyncClient.java
+++ b/src/main/java/io/dgraph/DgraphAsyncClient.java
@@ -97,64 +97,65 @@ public class DgraphAsyncClient {
    */
   public CompletableFuture<Void> loginIntoNamespace(
       String userid, String password, long namespace) {
-    Lock wlock = jwtLock.writeLock();
-    wlock.lock();
-    try {
-      final DgraphGrpc.DgraphStub client = anyClient();
-      final DgraphProto.LoginRequest loginRequest =
-          DgraphProto.LoginRequest.newBuilder()
-              .setUserid(userid)
-              .setPassword(password)
-              .setNamespace(namespace)
-              .build();
+    final DgraphGrpc.DgraphStub client = anyClient();
+    final DgraphProto.LoginRequest loginRequest =
+        DgraphProto.LoginRequest.newBuilder()
+            .setUserid(userid)
+            .setPassword(password)
+            .setNamespace(namespace)
+            .build();
 
-      StreamObserverBridge<DgraphProto.Response> bridge = new StreamObserverBridge<>();
-      client.login(loginRequest, bridge);
-      return bridge
-          .getDelegate()
-          .thenAccept(
-              (DgraphProto.Response response) -> {
-                try {
-                  // set the jwt field
-                  jwt = DgraphProto.Jwt.parseFrom(response.getJson());
-                } catch (InvalidProtocolBufferException e) {
-                  String errmsg = "error while parsing jwt from the response: ";
-                  LOG.error(errmsg, e);
-                  throw new AuthException(errmsg, e);
-                }
-              });
-    } finally {
-      wlock.unlock();
-    }
+    StreamObserverBridge<DgraphProto.Response> bridge = new StreamObserverBridge<>();
+    client.login(loginRequest, bridge);
+    return bridge.getDelegate().thenAccept(response -> setJwt(response, true));
   }
 
   protected CompletableFuture<Void> retryLogin() {
-    Lock wlock = jwtLock.writeLock();
-    wlock.lock();
+    final String refreshJwt;
+    Lock rlock = jwtLock.readLock();
+    rlock.lock();
     try {
-      if (jwt.getRefreshJwt().isEmpty()) {
+      if (jwt == null || jwt.getRefreshJwt().isEmpty()) {
         CompletableFuture<Void> future = new CompletableFuture<>();
         future.completeExceptionally(new Exception("refresh JWT should not be empty"));
         return future;
       }
+      refreshJwt = jwt.getRefreshJwt();
+    } finally {
+      rlock.unlock();
+    }
 
-      final DgraphGrpc.DgraphStub client = anyClient();
-      final DgraphProto.LoginRequest loginRequest =
-          DgraphProto.LoginRequest.newBuilder().setRefreshToken(jwt.getRefreshJwt()).build();
+    final DgraphGrpc.DgraphStub client = anyClient();
+    final DgraphProto.LoginRequest loginRequest =
+        DgraphProto.LoginRequest.newBuilder().setRefreshToken(refreshJwt).build();
 
-      StreamObserverBridge<DgraphProto.Response> bridge = new StreamObserverBridge<>();
-      client.login(loginRequest, bridge);
-      return bridge
-          .getDelegate()
-          .thenAccept(
-              (DgraphProto.Response response) -> {
-                try {
-                  // set the jwt field
-                  jwt = DgraphProto.Jwt.parseFrom(response.getJson());
-                } catch (InvalidProtocolBufferException e) {
-                  LOG.error("error while parsing jwt from the response: ", e);
-                }
-              });
+    StreamObserverBridge<DgraphProto.Response> bridge = new StreamObserverBridge<>();
+    client.login(loginRequest, bridge);
+    return bridge.getDelegate().thenAccept(response -> setJwt(response, false));
+  }
+
+  /**
+   * Parses the JWT from a login/refresh response and stores it under the write lock. This is the
+   * only writer of the {@code jwt} field; running it under the write lock (rather than around the
+   * RPC setup, as before) is what makes the write safely published to readers that hold the read
+   * lock in {@link #getStubWithJwt}.
+   *
+   * @param response the login or refresh response
+   * @param throwOnError if true (initial login), a parse failure throws AuthException; if false
+   *     (token refresh), it is logged and swallowed, preserving prior behavior
+   */
+  private void setJwt(DgraphProto.Response response, boolean throwOnError) {
+    Lock wlock = jwtLock.writeLock();
+    wlock.lock();
+    try {
+      jwt = DgraphProto.Jwt.parseFrom(response.getJson());
+    } catch (InvalidProtocolBufferException e) {
+      if (throwOnError) {
+        String errmsg = "error while parsing jwt from the response: ";
+        LOG.error(errmsg, e);
+        throw new AuthException(errmsg, e);
+      }
+      LOG.error("error while parsing jwt from the response: ", e);
     } finally {
       wlock.unlock();
     }

--- a/src/main/java/io/dgraph/DgraphAsyncClient.java
+++ b/src/main/java/io/dgraph/DgraphAsyncClient.java
@@ -46,13 +46,18 @@ public class DgraphAsyncClient {
    *
    * <p>A single client is thread safe.
    *
-   * <p>Uses {@link ForkJoinPool#commonPool()} as the callback executor. Use {@link
-   * #DgraphAsyncClient(Executor, DgraphGrpc.DgraphStub...)} to isolate this client's callback work
-   * from the common pool.
+   * <p>Uses {@link ForkJoinPool#commonPool()} as the callback executor.
    *
    * @param stubs - an array of grpc stubs to be used by this client. The stubs to be used are
    *     chosen at random per transaction.
+   * @deprecated Use {@link #DgraphAsyncClient(Executor, DgraphGrpc.DgraphStub...)} and supply an
+   *     executor sized for I/O continuations. {@link ForkJoinPool#commonPool()} is a JVM-wide
+   *     singleton sized {@code availableProcessors() - 1}, so a two-vCPU container gets one thread.
+   *     It cannot be tuned per library, its queue is unbounded, and its threads are unnamed
+   *     daemons, which hides contention in a thread dump. This constructor keeps the common pool
+   *     and will be removed in a future major release.
    */
+  @Deprecated
   public DgraphAsyncClient(DgraphGrpc.DgraphStub... stubs) {
     this.stubs = asList(stubs);
     this.executor = ForkJoinPool.commonPool();

--- a/src/main/java/io/dgraph/DgraphAsyncClient.java
+++ b/src/main/java/io/dgraph/DgraphAsyncClient.java
@@ -46,6 +46,11 @@ public class DgraphAsyncClient {
    *
    * <p>A single client is thread safe.
    *
+   * <p>Uses {@link ForkJoinPool#commonPool()} as the callback executor. This is safe because the
+   * client's callbacks never block; use
+   * {@link #DgraphAsyncClient(Executor, DgraphGrpc.DgraphStub...)} to supply a dedicated executor
+   * if you want to isolate this client's callback work.
+   *
    * @param stubs - an array of grpc stubs to be used by this client. The stubs to be used are
    *     chosen at random per transaction.
    */
@@ -60,7 +65,14 @@ public class DgraphAsyncClient {
    *
    * <p>A single client is thread safe.
    *
-   * @param executor - the executor to use for various asynchronous tasks executed by this client.
+   * <p>The executor is a <em>callback executor</em>: the client runs its continuation logic (JWT
+   * refresh handling, exception translation, retries) on it, and returned futures complete on it.
+   * gRPC I/O runs on the channel's own threads, and the client never blocks an executor thread for
+   * the duration of a call. Because these callbacks never block, the no-arg constructor's default
+   * of {@link ForkJoinPool#commonPool()} is safe; supply your own executor to isolate this
+   * client's callback work from the common pool.
+   *
+   * @param executor the callback executor for this client's continuation logic
    * @param stubs - an array of grpc stubs to be used by this client. The stubs to be used are
    *     chosen at random per transaction.
    */
@@ -150,12 +162,11 @@ public class DgraphAsyncClient {
     try {
       jwt = DgraphProto.Jwt.parseFrom(response.getJson());
     } catch (InvalidProtocolBufferException e) {
+      String errmsg = "error while parsing jwt from the response: ";
+      LOG.error(errmsg, e);
       if (throwOnError) {
-        String errmsg = "error while parsing jwt from the response: ";
-        LOG.error(errmsg, e);
         throw new AuthException(errmsg, e);
       }
-      LOG.error("error while parsing jwt from the response: ", e);
     } finally {
       wlock.unlock();
     }

--- a/src/main/java/io/dgraph/DgraphAsyncClient.java
+++ b/src/main/java/io/dgraph/DgraphAsyncClient.java
@@ -46,10 +46,9 @@ public class DgraphAsyncClient {
    *
    * <p>A single client is thread safe.
    *
-   * <p>Uses {@link ForkJoinPool#commonPool()} as the callback executor. This is safe because the
-   * client's callbacks never block; use
-   * {@link #DgraphAsyncClient(Executor, DgraphGrpc.DgraphStub...)} to supply a dedicated executor
-   * if you want to isolate this client's callback work.
+   * <p>Uses {@link ForkJoinPool#commonPool()} as the callback executor. Use {@link
+   * #DgraphAsyncClient(Executor, DgraphGrpc.DgraphStub...)} to isolate this client's callback work
+   * from the common pool.
    *
    * @param stubs - an array of grpc stubs to be used by this client. The stubs to be used are
    *     chosen at random per transaction.
@@ -66,11 +65,10 @@ public class DgraphAsyncClient {
    * <p>A single client is thread safe.
    *
    * <p>The executor is a <em>callback executor</em>: the client runs its continuation logic (JWT
-   * refresh handling, exception translation, retries) on it, and returned futures complete on it.
-   * gRPC I/O runs on the channel's own threads, and the client never blocks an executor thread for
-   * the duration of a call. Because these callbacks never block, the no-arg constructor's default
-   * of {@link ForkJoinPool#commonPool()} is safe; supply your own executor to isolate this
-   * client's callback work from the common pool.
+   * refresh handling, exception translation, retries) on it, and the futures it returns complete on
+   * it. gRPC I/O runs on the channel's own threads, and no executor thread is held for the duration
+   * of a call. Note that the client issues the first attempt of each call on the calling thread, so
+   * request serialization happens there rather than on the executor.
    *
    * @param executor the callback executor for this client's continuation logic
    * @param stubs - an array of grpc stubs to be used by this client. The stubs to be used are
@@ -128,9 +126,8 @@ public class DgraphAsyncClient {
     rlock.lock();
     try {
       if (jwt == null || jwt.getRefreshJwt().isEmpty()) {
-        CompletableFuture<Void> future = new CompletableFuture<>();
-        future.completeExceptionally(new Exception("refresh JWT should not be empty"));
-        return future;
+        return CompletableFuture.failedFuture(
+            new Exception("no refresh JWT available; call login first"));
       }
       refreshJwt = jwt.getRefreshJwt();
     } finally {
@@ -147,14 +144,13 @@ public class DgraphAsyncClient {
   }
 
   /**
-   * Parses the JWT from a login/refresh response and stores it under the write lock. This is the
-   * only writer of the {@code jwt} field; running it under the write lock (rather than around the
-   * RPC setup, as before) is what makes the write safely published to readers that hold the read
-   * lock in {@link #getStubWithJwt}.
+   * Parses the JWT from a login or refresh response and stores it. This is the only writer of the
+   * {@code jwt} field, and it holds the write lock so the write is published to readers in {@link
+   * #getStubWithJwt}.
    *
    * @param response the login or refresh response
    * @param throwOnError if true (initial login), a parse failure throws AuthException; if false
-   *     (token refresh), it is logged and swallowed, preserving prior behavior
+   *     (token refresh), it is logged and swallowed
    */
   private void setJwt(DgraphProto.Response response, boolean throwOnError) {
     Lock wlock = jwtLock.writeLock();

--- a/src/main/java/io/dgraph/DgraphAsyncClient.java
+++ b/src/main/java/io/dgraph/DgraphAsyncClient.java
@@ -632,11 +632,8 @@ public class DgraphAsyncClient {
         policy,
         op,
         0,
-        () -> {
-          AsyncTransaction txn =
-              policy.isReadOnly() ? newReadOnlyTransaction() : newTransaction();
-          return txn;
-        });
+        () -> policy.isReadOnly() ? newReadOnlyTransaction() : newTransaction(),
+        this.executor);
   }
 
   /** Calls %{@link io.grpc.ManagedChannel#shutdown} on all connections for this client */

--- a/src/main/java/io/dgraph/DgraphAsyncClient.java
+++ b/src/main/java/io/dgraph/DgraphAsyncClient.java
@@ -117,7 +117,7 @@ public class DgraphAsyncClient {
 
     StreamObserverBridge<DgraphProto.Response> bridge = new StreamObserverBridge<>();
     client.login(loginRequest, bridge);
-    return bridge.getDelegate().thenAccept(response -> setJwt(response, true));
+    return bridge.getDelegate().thenAcceptAsync(response -> setJwt(response, true), executor);
   }
 
   protected CompletableFuture<Void> retryLogin() {
@@ -140,7 +140,7 @@ public class DgraphAsyncClient {
 
     StreamObserverBridge<DgraphProto.Response> bridge = new StreamObserverBridge<>();
     client.login(loginRequest, bridge);
-    return bridge.getDelegate().thenAccept(response -> setJwt(response, false));
+    return bridge.getDelegate().thenAcceptAsync(response -> setJwt(response, false), executor);
   }
 
   /**

--- a/src/main/java/io/dgraph/DgraphClient.java
+++ b/src/main/java/io/dgraph/DgraphClient.java
@@ -372,9 +372,15 @@ public class DgraphClient {
    *
    * <p>A single client is thread safe.
    *
+   * <p>Callbacks run on {@link java.util.concurrent.ForkJoinPool#commonPool()}. Prefer {@link
+   * #DgraphClient(Executor, DgraphGrpc.DgraphStub...)} to isolate this client's callback work.
+   *
    * @param stubs - an array of grpc stubs to be used by this client. The stubs to be used are
    *     chosen at random per transaction.
    */
+  // Delegates to the deprecated common-pool constructor on purpose: this overload's contract is
+  // that it supplies no executor.
+  @SuppressWarnings("deprecation")
   public DgraphClient(DgraphGrpc.DgraphStub... stubs) {
     this.asyncClient = new DgraphAsyncClient(stubs);
   }

--- a/src/main/java/io/dgraph/Transaction.java
+++ b/src/main/java/io/dgraph/Transaction.java
@@ -235,6 +235,11 @@ public class Transaction implements AutoCloseable {
     asyncTransaction.setBestEffort(bestEffort);
   }
 
+  /**
+   * Discards the transaction, throwing if the abort fails. This diverges from {@link
+   * AsyncTransaction#close()}, which logs the failure instead. Closing here is user-invoked through
+   * try-with-resources, so the caller can act on the failure.
+   */
   @Override
   public void close() {
     Exceptions.withExceptionUnwrapped(this::discard);

--- a/src/test/java/io/dgraph/CompletableFuturesTest.java
+++ b/src/test/java/io/dgraph/CompletableFuturesTest.java
@@ -41,9 +41,8 @@ public class CompletableFuturesTest {
   private static final Supplier<CompletableFuture<Void>> NO_RETRY_NEEDED =
       () -> CompletableFuture.completedFuture(null);
 
-  // The regression test for #293: an in-flight (never-completing) call must not
-  // hold an executor thread hostage. On the old blocking implementation the
-  // single executor thread parks on .get() and the marker never runs.
+  // Regression test for #293: an in-flight call must not hold an executor thread hostage.
+  // On the old blocking implementation the lone executor thread parks and the marker never runs.
   @Test
   public void inFlightCallDoesNotHoldExecutorThread() throws Exception {
     ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -163,6 +162,42 @@ public class CompletableFuturesTest {
           e.getCause() instanceof ConnectionException, "cause was " + e.getCause());
     }
     assertEquals(calls.get(), 2);
+  }
+
+  // The callback executor is the documented completion thread for every path, including the
+  // JWT-retry path, whose gRPC future completes on a channel thread we do not control.
+  @Test
+  public void retryPathCompletesOnCallbackExecutor() throws Exception {
+    ExecutorService executor =
+        Executors.newSingleThreadExecutor(r -> new Thread(r, "callback-executor"));
+    try {
+      CompletableFuture<String> first = new CompletableFuture<>();
+      CompletableFuture<String> retry = new CompletableFuture<>();
+      CountDownLatch retryInvoked = new CountDownLatch(1);
+      AtomicInteger calls = new AtomicInteger();
+      Callable<CompletableFuture<String>> callable =
+          () -> {
+            if (calls.incrementAndGet() == 1) {
+              return first;
+            }
+            retryInvoked.countDown();
+            return retry;
+          };
+
+      CompletableFuture<String> completedOn =
+          CompletableFutures.runWithRetries("op", callable, NO_RETRY_NEEDED, executor)
+              .thenApply(ignored -> Thread.currentThread().getName());
+
+      first.completeExceptionally(jwtExpired());
+      assertTrue(retryInvoked.await(2, TimeUnit.SECONDS), "retry was never attempted");
+      // FIFO on a single-thread executor: by the time this task runs, runWithRetries has
+      // composed on the retry future, so completing it off-executor exercises the hop back.
+      executor.execute(() -> new Thread(() -> retry.complete("ok"), "grpc-thread").start());
+
+      assertEquals(completedOn.get(2, TimeUnit.SECONDS), "callback-executor");
+    } finally {
+      executor.shutdownNow();
+    }
   }
 
   @Test

--- a/src/test/java/io/dgraph/CompletableFuturesTest.java
+++ b/src/test/java/io/dgraph/CompletableFuturesTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
@@ -46,6 +47,26 @@ public class CompletableFuturesTest {
 
   private static final Supplier<CompletableFuture<Void>> NO_RETRY_NEEDED =
       () -> CompletableFuture.completedFuture(null);
+
+  /** Accepts the first {@code limit} submissions, then rejects, like a saturated AbortPolicy. */
+  private static final class RejectAfter implements Executor {
+    private final ExecutorService delegate;
+    private final int limit;
+    private final AtomicInteger submissions = new AtomicInteger();
+
+    RejectAfter(ExecutorService delegate, int limit) {
+      this.delegate = delegate;
+      this.limit = limit;
+    }
+
+    @Override
+    public void execute(Runnable command) {
+      if (submissions.incrementAndGet() > limit) {
+        throw new RejectedExecutionException("saturated");
+      }
+      delegate.execute(command);
+    }
+  }
 
   // Regression test for #293: an in-flight call must not hold an executor thread hostage.
   // On the old blocking implementation the lone executor thread parks and the marker never runs.
@@ -250,6 +271,85 @@ public class CompletableFuturesTest {
     } finally {
       channel.shutdownNow();
       executor.shutdownNow();
+    }
+  }
+
+  // A bounded executor with the default AbortPolicy rejects under load. Every rejection must
+  // surface as a DgraphException, not as a raw RejectedExecutionException.
+  @Test
+  public void executorRejectionIsTranslated() throws Exception {
+    ExecutorService delegate = Executors.newSingleThreadExecutor();
+    try {
+      Executor executor = new RejectAfter(delegate, 0);
+      Callable<CompletableFuture<String>> callable =
+          () -> CompletableFuture.completedFuture("ok");
+
+      CompletableFuture<String> result =
+          CompletableFutures.runWithRetries("op", callable, NO_RETRY_NEEDED, executor);
+
+      try {
+        result.get(2, TimeUnit.SECONDS);
+        fail("expected failure");
+      } catch (ExecutionException e) {
+        assertTrue(e.getCause() instanceof DgraphException, "cause was " + e.getCause());
+      }
+    } finally {
+      delegate.shutdownNow();
+    }
+  }
+
+  // attemptAsync completes its result only from inside the callback, so a rejection of that
+  // callback must be relayed or the caller waits forever.
+  @Test
+  public void rejectedCallbackFailsInsteadOfHanging() throws Exception {
+    ExecutorService delegate = Executors.newSingleThreadExecutor();
+    ManagedChannel channel = ManagedChannelBuilder.forTarget("localhost:1").usePlaintext().build();
+    try {
+      Executor executor = new RejectAfter(delegate, 0);
+      DgraphAsyncClient client = new DgraphAsyncClient(executor, DgraphGrpc.newStub(channel));
+      RetryPolicy policy = RetryPolicy.builder().maxRetries(2).build();
+
+      AsyncTransactionOp<String> op = txn -> CompletableFuture.completedFuture("ok");
+      CompletableFuture<String> result =
+          CompletableFutures.attemptAsync(policy, op, 0, client::newTransaction, executor);
+
+      try {
+        result.get(5, TimeUnit.SECONDS);
+        fail("expected failure");
+      } catch (ExecutionException e) {
+        assertTrue(e.getCause() instanceof DgraphException, "cause was " + e.getCause());
+      }
+    } finally {
+      channel.shutdownNow();
+      delegate.shutdownNow();
+    }
+  }
+
+  // The backoff hop is the second submission. delayedExecutor must not carry the user executor:
+  // a rejection raised on the internal Delayer thread is swallowed and the retry never completes.
+  @Test
+  public void rejectedBackoffHopFailsInsteadOfHanging() throws Exception {
+    ExecutorService delegate = Executors.newSingleThreadExecutor();
+    ManagedChannel channel = ManagedChannelBuilder.forTarget("localhost:1").usePlaintext().build();
+    try {
+      Executor executor = new RejectAfter(delegate, 1);
+      DgraphAsyncClient client = new DgraphAsyncClient(executor, DgraphGrpc.newStub(channel));
+      RetryPolicy policy =
+          RetryPolicy.builder().maxRetries(2).baseDelay(Duration.ofMillis(10)).jitter(0).build();
+
+      AsyncTransactionOp<String> op = txn -> failed(unavailable());
+      CompletableFuture<String> result =
+          CompletableFutures.attemptAsync(policy, op, 0, client::newTransaction, executor);
+
+      try {
+        result.get(5, TimeUnit.SECONDS);
+        fail("expected failure");
+      } catch (ExecutionException e) {
+        assertTrue(e.getCause() instanceof DgraphException, "cause was " + e.getCause());
+      }
+    } finally {
+      channel.shutdownNow();
+      delegate.shutdownNow();
     }
   }
 

--- a/src/test/java/io/dgraph/CompletableFuturesTest.java
+++ b/src/test/java/io/dgraph/CompletableFuturesTest.java
@@ -7,8 +7,14 @@ package io.dgraph;
 
 import static org.testng.Assert.*;
 
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -196,6 +202,53 @@ public class CompletableFuturesTest {
 
       assertEquals(completedOn.get(2, TimeUnit.SECONDS), "callback-executor");
     } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  // attemptAsync's backoff used delayedExecutor(delay, unit), which targets the common pool and
+  // ignored the executor the client was built with. Nothing here contacts a server.
+  @Test
+  public void retryBackoffAndCompletionRunOnSuppliedExecutor() throws Exception {
+    ExecutorService executor =
+        Executors.newSingleThreadExecutor(r -> new Thread(r, "retry-executor"));
+    ManagedChannel channel = ManagedChannelBuilder.forTarget("localhost:1").usePlaintext().build();
+    try {
+      DgraphAsyncClient client = new DgraphAsyncClient(executor, DgraphGrpc.newStub(channel));
+      RetryPolicy policy =
+          RetryPolicy.builder().maxRetries(2).baseDelay(Duration.ofMillis(10)).jitter(0).build();
+
+      AtomicInteger attempts = new AtomicInteger();
+      List<String> attemptThreads = Collections.synchronizedList(new ArrayList<>());
+      CompletableFuture<String> secondAttempt = new CompletableFuture<>();
+      CountDownLatch retryStarted = new CountDownLatch(1);
+      AsyncTransactionOp<String> op =
+          txn -> {
+            attemptThreads.add(Thread.currentThread().getName());
+            if (attempts.incrementAndGet() == 1) {
+              return failed(unavailable());
+            }
+            retryStarted.countDown();
+            return secondAttempt;
+          };
+
+      CompletableFuture<String> result =
+          CompletableFutures.attemptAsync(policy, op, 0, client::newTransaction, executor);
+      CompletableFuture<String> completedOn =
+          result.thenApply(ignored -> Thread.currentThread().getName());
+
+      assertTrue(retryStarted.await(5, TimeUnit.SECONDS), "the retry never ran");
+      // FIFO on the single-thread executor: this task runs after attemptAsync composed on
+      // secondAttempt, so completing it off-executor exercises the hop back.
+      executor.execute(
+          () -> new Thread(() -> secondAttempt.complete("ok"), "grpc-thread").start());
+
+      assertEquals(result.get(5, TimeUnit.SECONDS), "ok");
+      assertEquals(attempts.get(), 2, "the retryable failure should be retried once");
+      assertEquals(attemptThreads.get(1), "retry-executor", "backoff ran off the given executor");
+      assertEquals(completedOn.get(5, TimeUnit.SECONDS), "retry-executor");
+    } finally {
+      channel.shutdownNow();
       executor.shutdownNow();
     }
   }

--- a/src/test/java/io/dgraph/CompletableFuturesTest.java
+++ b/src/test/java/io/dgraph/CompletableFuturesTest.java
@@ -1,0 +1,175 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.dgraph;
+
+import static org.testng.Assert.*;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.testng.annotations.Test;
+
+public class CompletableFuturesTest {
+
+  private static <T> CompletableFuture<T> failed(Throwable t) {
+    CompletableFuture<T> f = new CompletableFuture<>();
+    f.completeExceptionally(t);
+    return f;
+  }
+
+  private static StatusRuntimeException jwtExpired() {
+    return Status.UNAUTHENTICATED.withDescription("Token is expired").asRuntimeException();
+  }
+
+  private static StatusRuntimeException unavailable() {
+    return Status.UNAVAILABLE.withDescription("connection refused").asRuntimeException();
+  }
+
+  private static final Supplier<CompletableFuture<Void>> NO_RETRY_NEEDED =
+      () -> CompletableFuture.completedFuture(null);
+
+  // The regression test for #293: an in-flight (never-completing) call must not
+  // hold an executor thread hostage. On the old blocking implementation the
+  // single executor thread parks on .get() and the marker never runs.
+  @Test
+  public void inFlightCallDoesNotHoldExecutorThread() throws Exception {
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      for (int i = 0; i < 3; i++) {
+        CompletableFuture<String> hung = new CompletableFuture<>();
+        CompletableFutures.runWithRetries("op", () -> hung, NO_RETRY_NEEDED, executor);
+      }
+      CountDownLatch marker = new CountDownLatch(1);
+      executor.execute(marker::countDown);
+      assertTrue(
+          marker.await(2, TimeUnit.SECONDS),
+          "executor thread was starved by an in-flight gRPC call");
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  public void successPassesThrough() throws Exception {
+    Executor executor = ForkJoinPool.commonPool();
+    Callable<CompletableFuture<String>> callable =
+        () -> CompletableFuture.completedFuture("ok");
+
+    CompletableFuture<String> result =
+        CompletableFutures.runWithRetries("op", callable, NO_RETRY_NEEDED, executor);
+
+    assertEquals(result.get(2, TimeUnit.SECONDS), "ok");
+  }
+
+  @Test
+  public void nonJwtErrorIsTranslatedAndNotRetried() throws Exception {
+    Executor executor = ForkJoinPool.commonPool();
+    AtomicInteger logins = new AtomicInteger();
+    Supplier<CompletableFuture<Void>> retryLogin =
+        () -> {
+          logins.incrementAndGet();
+          return CompletableFuture.completedFuture(null);
+        };
+    Callable<CompletableFuture<String>> callable = () -> failed(unavailable());
+
+    CompletableFuture<String> result =
+        CompletableFutures.runWithRetries("op", callable, retryLogin, executor);
+
+    try {
+      result.get(2, TimeUnit.SECONDS);
+      fail("expected failure");
+    } catch (ExecutionException e) {
+      assertTrue(
+          e.getCause() instanceof ConnectionException, "cause was " + e.getCause());
+    }
+    assertEquals(logins.get(), 0, "retryLogin must not run for a non-JWT error");
+  }
+
+  @Test
+  public void jwtExpiryTriggersRetryThenSucceeds() throws Exception {
+    Executor executor = ForkJoinPool.commonPool();
+    AtomicInteger calls = new AtomicInteger();
+    AtomicInteger logins = new AtomicInteger();
+    Callable<CompletableFuture<String>> callable =
+        () -> {
+          if (calls.incrementAndGet() == 1) {
+            return failed(jwtExpired());
+          }
+          return CompletableFuture.completedFuture("ok");
+        };
+    Supplier<CompletableFuture<Void>> retryLogin =
+        () -> {
+          logins.incrementAndGet();
+          return CompletableFuture.completedFuture(null);
+        };
+
+    CompletableFuture<String> result =
+        CompletableFutures.runWithRetries("op", callable, retryLogin, executor);
+
+    assertEquals(result.get(2, TimeUnit.SECONDS), "ok");
+    assertEquals(calls.get(), 2, "callable should be invoked twice (original + retry)");
+    assertEquals(logins.get(), 1, "retryLogin should run exactly once");
+  }
+
+  @Test
+  public void jwtExpiryRetryFailureIsTranslated() throws Exception {
+    Executor executor = ForkJoinPool.commonPool();
+    AtomicInteger calls = new AtomicInteger();
+    Callable<CompletableFuture<String>> callable =
+        () -> {
+          if (calls.incrementAndGet() == 1) {
+            return failed(jwtExpired());
+          }
+          return failed(unavailable());
+        };
+
+    CompletableFuture<String> result =
+        CompletableFutures.runWithRetries("op", callable, NO_RETRY_NEEDED, executor);
+
+    try {
+      result.get(2, TimeUnit.SECONDS);
+      fail("expected failure");
+    } catch (ExecutionException e) {
+      assertTrue(
+          e.getCause() instanceof ConnectionException, "cause was " + e.getCause());
+    }
+    assertEquals(calls.get(), 2);
+  }
+
+  @Test
+  public void retryLoginFailureIsTranslated() throws Exception {
+    Executor executor = ForkJoinPool.commonPool();
+    AtomicInteger calls = new AtomicInteger();
+    Callable<CompletableFuture<String>> callable =
+        () -> {
+          calls.incrementAndGet();
+          return failed(jwtExpired());
+        };
+    Supplier<CompletableFuture<Void>> retryLogin =
+        () -> failed(new RuntimeException("refresh failed"));
+
+    CompletableFuture<String> result =
+        CompletableFutures.runWithRetries("op", callable, retryLogin, executor);
+
+    try {
+      result.get(2, TimeUnit.SECONDS);
+      fail("expected failure");
+    } catch (ExecutionException e) {
+      assertTrue(e.getCause() instanceof DgraphException, "cause was " + e.getCause());
+    }
+    assertEquals(calls.get(), 1, "callable must not be retried when login refresh fails");
+  }
+}

--- a/src/test/java/io/dgraph/CompletableFuturesTest.java
+++ b/src/test/java/io/dgraph/CompletableFuturesTest.java
@@ -206,6 +206,7 @@ public class CompletableFuturesTest {
   public void retryPathCompletesOnCallbackExecutor() throws Exception {
     ExecutorService executor =
         Executors.newSingleThreadExecutor(r -> new Thread(r, "callback-executor"));
+    CountDownLatch release = new CountDownLatch(1);
     try {
       CompletableFuture<String> first = new CompletableFuture<>();
       CompletableFuture<String> retry = new CompletableFuture<>();
@@ -220,18 +221,31 @@ public class CompletableFuturesTest {
             return retry;
           };
 
-      CompletableFuture<String> completedOn =
-          CompletableFutures.runWithRetries("op", callable, NO_RETRY_NEEDED, executor)
-              .thenApply(ignored -> Thread.currentThread().getName());
+      CompletableFuture<String> result =
+          CompletableFutures.runWithRetries("op", callable, NO_RETRY_NEEDED, executor);
 
       first.completeExceptionally(jwtExpired());
-      assertTrue(retryInvoked.await(2, TimeUnit.SECONDS), "retry was never attempted");
-      // FIFO on a single-thread executor: by the time this task runs, runWithRetries has
-      // composed on the retry future, so completing it off-executor exercises the hop back.
-      executor.execute(() -> new Thread(() -> retry.complete("ok"), "grpc-thread").start());
+      assertTrue(retryInvoked.await(5, TimeUnit.SECONDS), "retry was never attempted");
 
-      assertEquals(completedOn.get(2, TimeUnit.SECONDS), "callback-executor");
+      // Occupancy, not thread identity: naming the completing thread needs a non-async stage on
+      // result, and the get() below can drain that stage and run it on the test thread instead.
+      CountDownLatch occupied = new CountDownLatch(1);
+      executor.execute(
+          () -> {
+            occupied.countDown();
+            awaitQuietly(release);
+          });
+      assertTrue(occupied.await(5, TimeUnit.SECONDS), "the executor never ran the blocker");
+
+      Thread grpcThread = new Thread(() -> retry.complete("ok"), "grpc-thread");
+      grpcThread.start();
+      grpcThread.join(TimeUnit.SECONDS.toMillis(5));
+      assertFalse(result.isDone(), "the retry completed off the callback executor");
+
+      release.countDown();
+      assertEquals(result.get(5, TimeUnit.SECONDS), "ok");
     } finally {
+      release.countDown();
       executor.shutdownNow();
     }
   }

--- a/src/test/java/io/dgraph/CompletableFuturesTest.java
+++ b/src/test/java/io/dgraph/CompletableFuturesTest.java
@@ -75,6 +75,22 @@ public class CompletableFuturesTest {
   }
 
   @Test
+  public void nullFutureFromCallableIsTranslated() throws Exception {
+    Executor executor = ForkJoinPool.commonPool();
+    Callable<CompletableFuture<String>> callable = () -> null;
+
+    CompletableFuture<String> result =
+        CompletableFutures.runWithRetries("op", callable, NO_RETRY_NEEDED, executor);
+
+    try {
+      result.get(2, TimeUnit.SECONDS);
+      fail("expected failure");
+    } catch (ExecutionException e) {
+      assertTrue(e.getCause() instanceof DgraphException, "cause was " + e.getCause());
+    }
+  }
+
+  @Test
   public void nonJwtErrorIsTranslatedAndNotRetried() throws Exception {
     Executor executor = ForkJoinPool.commonPool();
     AtomicInteger logins = new AtomicInteger();

--- a/src/test/java/io/dgraph/CompletableFuturesTest.java
+++ b/src/test/java/io/dgraph/CompletableFuturesTest.java
@@ -48,6 +48,15 @@ public class CompletableFuturesTest {
   private static final Supplier<CompletableFuture<Void>> NO_RETRY_NEEDED =
       () -> CompletableFuture.completedFuture(null);
 
+  /** Waits inside a task, restoring the interrupt flag so shutdownNow still ends the task. */
+  private static void awaitQuietly(CountDownLatch latch) {
+    try {
+      latch.await();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
   /** Accepts the first {@code limit} submissions, then rejects, like a saturated AbortPolicy. */
   private static final class RejectAfter implements Executor {
     private final ExecutorService delegate;
@@ -227,13 +236,14 @@ public class CompletableFuturesTest {
     }
   }
 
-  // attemptAsync's backoff used delayedExecutor(delay, unit), which targets the common pool and
-  // ignored the executor the client was built with. Nothing here contacts a server.
+  // attemptAsync's backoff used delayedExecutor(delay, unit), which targets the common pool, and
+  // completed the result straight from the gRPC thread. Nothing here contacts a server.
   @Test
   public void retryBackoffAndCompletionRunOnSuppliedExecutor() throws Exception {
     ExecutorService executor =
         Executors.newSingleThreadExecutor(r -> new Thread(r, "retry-executor"));
     ManagedChannel channel = ManagedChannelBuilder.forTarget("localhost:1").usePlaintext().build();
+    CountDownLatch release = new CountDownLatch(1);
     try {
       DgraphAsyncClient client = new DgraphAsyncClient(executor, DgraphGrpc.newStub(channel));
       RetryPolicy policy =
@@ -255,20 +265,31 @@ public class CompletableFuturesTest {
 
       CompletableFuture<String> result =
           CompletableFutures.attemptAsync(policy, op, 0, client::newTransaction, executor);
-      CompletableFuture<String> completedOn =
-          result.thenApply(ignored -> Thread.currentThread().getName());
 
       assertTrue(retryStarted.await(5, TimeUnit.SECONDS), "the retry never ran");
-      // FIFO on the single-thread executor: this task runs after attemptAsync composed on
-      // secondAttempt, so completing it off-executor exercises the hop back.
-      executor.execute(
-          () -> new Thread(() -> secondAttempt.complete("ok"), "grpc-thread").start());
-
-      assertEquals(result.get(5, TimeUnit.SECONDS), "ok");
       assertEquals(attempts.get(), 2, "the retryable failure should be retried once");
+      // thenComposeAsync always dispatches through the executor, so this thread name is exact.
       assertEquals(attemptThreads.get(1), "retry-executor", "backoff ran off the given executor");
-      assertEquals(completedOn.get(5, TimeUnit.SECONDS), "retry-executor");
+
+      // Park the sole executor thread, then complete off-executor: if the completion hop is real
+      // it queues behind the blocker, and result stays pending until the blocker is released.
+      CountDownLatch occupied = new CountDownLatch(1);
+      executor.execute(
+          () -> {
+            occupied.countDown();
+            awaitQuietly(release);
+          });
+      assertTrue(occupied.await(5, TimeUnit.SECONDS), "the executor never ran the blocker");
+
+      Thread grpcThread = new Thread(() -> secondAttempt.complete("ok"), "grpc-thread");
+      grpcThread.start();
+      grpcThread.join(TimeUnit.SECONDS.toMillis(5));
+      assertFalse(result.isDone(), "completion ran off the given executor");
+
+      release.countDown();
+      assertEquals(result.get(5, TimeUnit.SECONDS), "ok");
     } finally {
+      release.countDown();
       channel.shutdownNow();
       executor.shutdownNow();
     }


### PR DESCRIPTION
**Description**

`DgraphAsyncClient` ran its async work on `ForkJoinPool.commonPool()` and blocked a pool thread for the full duration of every gRPC call: `CompletableFutures.runWithRetries` wrapped each call in `supplyAsync(...)` and then called a blocking `.get()` on the gRPC future. Under sustained or slow traffic this exhausted the JVM-wide common pool and could hang unrelated work (parallel streams, other `CompletableFuture` chains). Fixes #293.

This PR:

- Rewrites `runWithRetries` to compose on the `StreamObserverBridge` future (`handleAsync` plus a single JWT-expiry retry via `thenComposeAsync`) instead of blocking. No thread is parked for the round trip; the supplied `Executor` becomes a callback executor. The default `commonPool()` is now safe because the callbacks never block.
- Completes every path on that callback executor, including the JWT-retry path. Its gRPC future completes on a channel thread, so without an explicit hop back the returned future would complete there too, and any continuation the caller chained without an `Async` variant would run on gRPC's event loop — where a blocking callback stalls every RPC on the channel.
- Preserves the observed exception exactly: every failure completes the returned future with `CompletionException(DgraphException)`, so `.join()` in the synchronous `DgraphClient` still surfaces the typed `DgraphException`.
- Fixes an adjacent race in the login/refresh path: the `jwt` field was written inside a `thenAccept` callback after the write lock was released, leaving the write unguarded and unpublished. The write now happens in a write-lock-held setter, and the refresh token is read under the read lock.
- Adds `CompletableFuturesTest` — server-free unit tests, including a regression test that reproduces the common-pool starvation, one that pins the completion thread to the callback executor, plus retry and exception-translation characterization tests.

**Behavior change to note**

The first attempt of each call now runs on the calling thread, so request serialization happens there instead of on the executor. `supplyAsync` previously moved it to a pool thread. This removes a thread hop from every call, but callers issuing requests from a latency-sensitive thread should know where that work lands. The constructor Javadoc states it.

No public API changes. The `Executor` constructor parameter's meaning is a compatible superset (callback executor), documented in the constructor Javadoc.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to
      this PR
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable
