### PR TITLE
chore: remove the dead integrationTest source set and task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+**Removed**
+
+- chore: remove the `integrationTest` source set and task. Neither had ever run: the configured
+  source directory `src/integration-test/java` does not exist, the task never called `useTestNG()`
+  so it would have run none of this project's TestNG tests, its dependency configurations extended
+  `testCompile`/`testRuntime` (removed in Gradle 7, and this project builds with Gradle 8), and
+  nothing wired it into `check` or CI. Splitting the cluster-dependent tests out of `src/test`
+  remains worth doing, and needs scaffolding that works. ([#296])
+
 ## [25.0.0] - 2026-04-01
 
 **Added**
@@ -104,6 +113,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/),
 
 - chore: added a test for best effort queries ([#182])
 
+[#296]: https://github.com/dgraph-io/dgraph4j/pull/296
 [#287]: https://github.com/dgraph-io/dgraph4j/pull/287
 [#220]: https://github.com/hypermodeinc/dgraph4j/pull/220
 [#215]: https://github.com/hypermodeinc/dgraph4j/pull/215

--- a/build.gradle
+++ b/build.gradle
@@ -80,23 +80,6 @@ repositories {
     mavenCentral()
 }
 
-// configurations for the integration test
-sourceSets {
-    integrationTest {
-        java {
-            compileClasspath += main.output + test.output
-            runtimeClasspath += main.output + test.output
-            srcDir file('src/integration-test/java')
-        }
-        resources.srcDir file('src/integration-test/resources')
-    }
-}
-
-configurations {
-    integrationTestCompile.extendsFrom testCompile
-    integrationTestRuntime.extendsFrom testRuntime
-}
-
 // In this section you declare the dependencies for your production and test code
 dependencies {
     // The production code uses the SLF4J logging API at compile time
@@ -184,11 +167,6 @@ task setupCluster(type: Exec) {
     workingDir System.getenv('GOPATH') + '/src/github.com/dgraph-io/dgraph'
 
     commandLine './run.sh'
-}
-
-task integrationTest(type: Test) {
-    testClassesDirs = sourceSets.integrationTest.output.classesDirs
-    classpath = sourceSets.integrationTest.runtimeClasspath
 }
 
 artifacts {


### PR DESCRIPTION
**Description**

`build.gradle` declares an `integrationTest` source set and a matching `Test` task. Neither has ever run anything. Four independent reasons, each sufficient on its own:

1. The configured source directory, `src/integration-test/java`, does not exist. Nor does `src/integration-test/resources`.
2. `task integrationTest(type: Test)` never calls `useTestNG()`. It would default to JUnit 4 and run none of this project's TestNG tests even if sources appeared.
3. Its dependency configurations extend `testCompile` and `testRuntime`, both removed in Gradle 7. This project builds with Gradle 8.14.2.
4. Nothing wires the task into `check`, and CI runs `./gradlew build -i`, which excludes it.

Removing it also drops four no-op tasks from `./gradlew tasks` (`compileIntegrationTestJava`, `extractIntegrationTestProto`, `generateIntegrationTestProto`, `processIntegrationTestResources`) plus the `integrationTest` task itself. Their presence suggests a working unit/integration split exists, which sends anyone looking for one down a dead end.

**What this does not do**

Splitting the cluster-dependent tests out of `src/test` is still worth doing. 19 of the 23 test classes need a live cluster, so `./gradlew test` cannot run without one — awkward now that the suite has genuinely server-free tests. That work needs scaffolding that functions, and it touches the CI workflow, so it belongs in its own change rather than being grafted onto a cleanup.

**Verification**

- `./gradlew build -x test` succeeds.
- `./gradlew tasks --all` no longer lists any `integrationTest` task; nothing else references the source set.
- Server-free tests still run (`ExceptionMappingTest`, `RetryPolicyTest`).

No source or public API changes.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to
      this PR
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable —
      n/a, this removes build configuration and adds no behavior

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dgraph-io/codesmith/dgraph4j/pr/296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788617882&installation_model_id=8575&pr_number=296&repository=dgraph-io%2Fdgraph4j&return_to=https%3A%2F%2Fgithub.com%2Fdgraph-io%2Fdgraph4j%2Fpull%2F296&signature=26c6cb57895c301b94b8d6d547f1903e6496a8f836950ad876b2e0067a6c0233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->