### PR TITLE
fix: report a missing refresh token as AuthException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/),
 - fix: a `RejectedExecutionException` from the callback executor no longer leaves the returned
   future permanently incomplete. `withRetry` now relays the rejection instead of hanging, and every
   rejection surfaces as a `DgraphException` like any other failure. ([#294])
+- fix: a JWT refresh attempted with no refresh token now fails with `AuthException` carrying
+  `UNAUTHENTICATED`, completing the typed exception hierarchy. It previously threw a bare
+  `java.lang.Exception`, which `Exceptions.translate` flattened into a generic `DgraphException`
+  reporting `INTERNAL`. Code catching `DgraphException` is unaffected; code that distinguishes
+  `AuthException` now sees this case. ([#297])
 
 **Deprecated**
 
@@ -139,6 +144,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/),
 
 - chore: added a test for best effort queries ([#182])
 
+[#297]: https://github.com/dgraph-io/dgraph4j/pull/297
 [#294]: https://github.com/dgraph-io/dgraph4j/pull/294
 [#287]: https://github.com/dgraph-io/dgraph4j/pull/287
 [#220]: https://github.com/hypermodeinc/dgraph4j/pull/220

--- a/src/main/java/io/dgraph/DgraphAsyncClient.java
+++ b/src/main/java/io/dgraph/DgraphAsyncClient.java
@@ -14,6 +14,7 @@ import io.dgraph.DgraphProto.Version;
 import io.grpc.Channel;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
+import io.grpc.Status;
 import io.grpc.stub.MetadataUtils;
 import java.util.Collections;
 import java.util.List;
@@ -132,7 +133,10 @@ public class DgraphAsyncClient {
     try {
       if (jwt == null || jwt.getRefreshJwt().isEmpty()) {
         return CompletableFuture.failedFuture(
-            new Exception("no refresh JWT available; call login first"));
+            new AuthException(
+                Status.UNAUTHENTICATED.withDescription(
+                    "no refresh JWT available; call login first"),
+                null));
       }
       refreshJwt = jwt.getRefreshJwt();
     } finally {

--- a/src/test/java/io/dgraph/RetryLoginTest.java
+++ b/src/test/java/io/dgraph/RetryLoginTest.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.dgraph;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Status;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * A JWT refresh attempted without a refresh token must fail as an auth error. No RPC is issued, so
+ * these need no server: the missing-token check short-circuits before the login call.
+ */
+public class RetryLoginTest {
+
+  private ManagedChannel channel;
+  private ExecutorService executor;
+  private DgraphAsyncClient client;
+
+  @BeforeMethod
+  public void setUp() {
+    channel = ManagedChannelBuilder.forTarget("localhost:1").usePlaintext().build();
+    executor = Executors.newSingleThreadExecutor();
+    client = new DgraphAsyncClient(executor, DgraphGrpc.newStub(channel));
+  }
+
+  @AfterMethod(alwaysRun = true)
+  public void tearDown() {
+    channel.shutdownNow();
+    executor.shutdownNow();
+  }
+
+  @Test
+  public void refreshWithoutATokenFailsWithAuthException() {
+    CompletableFuture<Void> refreshed = client.retryLogin();
+
+    assertTrue(refreshed.isCompletedExceptionally(), "the refresh should fail immediately");
+    try {
+      refreshed.join();
+      fail("expected the refresh to fail");
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause() == null ? e : e.getCause();
+      assertTrue(cause instanceof AuthException, "cause was " + cause);
+      assertEquals(
+          Status.fromThrowable(cause).getCode(),
+          Status.Code.UNAUTHENTICATED,
+          "a missing refresh token is an authentication failure, not an internal error");
+    }
+  }
+
+  // The user-visible path: an expired token with no way to refresh it must surface as AuthException
+  // rather than a generic DgraphException.
+  @Test
+  public void expiredTokenWithNoRefreshSurfacesAuthException() throws Exception {
+    Callable<CompletableFuture<String>> expired =
+        () ->
+            CompletableFuture.failedFuture(
+                Status.UNAUTHENTICATED
+                    .withDescription("Token is expired")
+                    .asRuntimeException());
+
+    CompletableFuture<String> result =
+        CompletableFutures.runWithRetries("op", expired, client::retryLogin, executor);
+
+    try {
+      result.get(5, TimeUnit.SECONDS);
+      fail("expected the operation to fail");
+    } catch (ExecutionException e) {
+      assertTrue(e.getCause() instanceof AuthException, "cause was " + e.getCause());
+    }
+  }
+}


### PR DESCRIPTION
> **Stacked on dgraph-io/dgraph4j#294** ("fix: make DgraphAsyncClient non-blocking to avoid ForkJoinPool.commonPool starvation") as GitHub stack #298. The base is that branch, not `main`, because #294 rewrote the exact lines this changes. Read #294 first; the diff here is just this commit.

**Merge path**

Draft until the test suite has actually run on it. `ci-dgraph4j-tests.yml` and `trunk.yml` both gate their `pull_request` trigger on `branches: main`, so while this PR targets a feature branch it gets CodeQL but neither the test suite nor the linters. GitHub still reports it `MERGEABLE` and `CLEAN`, because absent checks cannot fail — judge it by which checks are present, not by its merge state.

Merging bottom-up closes that gap with no changes to CI:

1. Merge #294. It has a full green run against `main`.
2. This PR is retargeted to `main` automatically. The repo has `delete_branch_on_merge` enabled, and GitHub retargets open PRs based on a deleted head branch to the merged PR's base.
3. Mark this PR ready for review. `ready_for_review` is in the workflow's trigger list, so with the base now `main` the full suite and the linters run here.
4. Merge once green.

`gh stack merge 298` would instead land both PRs atomically, which is faster but merges this one without the suite ever running on it — the post-merge `push: main` run would catch a problem after the fact rather than before. dgraph-io/dgraph4j#299 ("ci: run tests and linters on pull requests to any base branch") removes the base-branch filter that causes this, and once it merges the checks appear here and either path is validated. Until then, prefer the sequence above.

**Description**

`retryLogin()` signalled "no refresh JWT available" with a bare `java.lang.Exception`. `Exceptions.translate` has no case for that, so it fell through to the generic wrapper and the caller saw a `DgraphException` reporting `INTERNAL` — an authentication failure presented as an internal error. It is the one gap left in the typed exception hierarchy added in 25.0.0, which already defines `AuthException` for exactly this condition.

This fails with `AuthException` carrying `Status.UNAUTHENTICATED` instead. `translate` passes `DgraphException` subclasses through untouched, so it reaches the caller intact.

**Compatibility**

- Retryability is unchanged. `AuthException` inherits `isRetryable() == false`, exactly as the generic `DgraphException` did, so `withRetry` behaves identically.
- `catch (DgraphException)` and `catch (StatusRuntimeException)` are unaffected — `AuthException` is a subclass of both.
- Only code that distinguishes `AuthException` sees a difference, which is the point of the change.
- The status code moves from `INTERNAL` to `UNAUTHENTICATED`. Code switching on the gRPC status code of this specific failure would observe that.

**Tests**

`RetryLoginTest` covers two cases, neither needing a server, since the missing-token check returns before any RPC is issued:

| Test | What it pins |
| --- | --- |
| `refreshWithoutATokenFailsWithAuthException` | the direct call fails with `AuthException` and `UNAUTHENTICATED` |
| `expiredTokenWithNoRefreshSurfacesAuthException` | the path a user hits — an expired token with no way to refresh it — surfaces `AuthException` through `runWithRetries` |

Both fail before this change: the first sees a raw `java.lang.Exception`, the second sees `DgraphException: INTERNAL`.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to
      this PR
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dgraph-io/codesmith/dgraph4j/pr/297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788617904&installation_model_id=8575&pr_number=297&repository=dgraph-io%2Fdgraph4j&return_to=https%3A%2F%2Fgithub.com%2Fdgraph-io%2Fdgraph4j%2Fpull%2F297&signature=428cf8186afe079ca6b1781f21c3197b5e5f3ca2866aaa70ef22849e02120d34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JWT refresh attempts without an available refresh token now fail with a clear `UNAUTHENTICATED` authentication error instead of a generic internal error.
  * Expired-token refresh failures now preserve the appropriate authentication error details.

* **Tests**
  * Added coverage for missing refresh tokens and expired-token retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->